### PR TITLE
feat: TTS 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### SDKMAN ###
 .sdkmanrc
+
+### MP3 Files ###
+*.mp3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 
     // Spring Boot Starters
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // Lombok for boilerplate code reduction

--- a/src/main/java/com/newworld/saegil/SaegilApplication.java
+++ b/src/main/java/com/newworld/saegil/SaegilApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class SaegilApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SaegilApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(SaegilApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/newworld/saegil/simulator/README.md
+++ b/src/main/java/com/newworld/saegil/simulator/README.md
@@ -1,0 +1,27 @@
+# OpenAI Controller Guide
+
+## curl 명령어로 TextToSpeech API 요청하기
+
+TextToSpeech API를 curl 명령어로 요청하는 방법은 다음과 같습니다:
+
+```bash
+curl -X POST \
+  http://localhost:8080/api/v1/tts/stream \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"안녕하세요, 반갑습니다. 새길팀 화이팅!! 이거 쉽지는 않겠지만 우리 한 번 열심히 해봐요!"}' \
+  --output speech.mp3
+```
+
+### 명령어 설명
+
+- `-X POST`: HTTP POST 메소드를 사용합니다.
+- `http://localhost:8080/api/v1/tts/stream`: 요청할 API 엔드포인트 URL입니다.
+- `-H 'Content-Type: application/json'`: 요청 헤더에 Content-Type을 JSON으로 지정합니다.
+- `-d '{"text":"안녕하세요, 반갑습니다."}'`: JSON 형식의 요청 본문을 지정합니다. 한국어 텍스트를 포함할 수 있습니다.
+- `--output speech.mp3`: 응답으로 받은 오디오 데이터를 speech.mp3 파일로 저장합니다.
+
+### 주의사항
+
+- 서버가 로컬에서 실행 중이어야 합니다 (포트 8080).
+- 환경 변수 `OPENAI_API_KEY`가 설정되어 있어야 합니다 (application-local.yml 설정 참조).
+- 응답은 MP3 형식의 오디오 파일로 저장됩니다.

--- a/src/main/java/com/newworld/saegil/simulator/controller/TextToSpeechController.java
+++ b/src/main/java/com/newworld/saegil/simulator/controller/TextToSpeechController.java
@@ -1,0 +1,34 @@
+package com.newworld.saegil.simulator.controller;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.newworld.saegil.simulator.dto.TextToSpeechRequest;
+import com.newworld.saegil.simulator.service.TextToSpeechService;
+
+import reactor.core.publisher.Flux;
+
+@RestController
+@RequestMapping("/api/v1/tts")
+public class TextToSpeechController {
+
+	private final TextToSpeechService textToSpeechService;
+
+	public TextToSpeechController(TextToSpeechService textToSpeechService) {
+		this.textToSpeechService = textToSpeechService;
+	}
+
+	@PostMapping(value = "/stream", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+	public Flux<DataBuffer> streamAudio(@RequestBody TextToSpeechRequest request) {
+		return textToSpeechService.streamSpeech(request.getText())
+								  .map(response -> {
+									  byte[] audioBytes = response.getResult().getOutput();
+									  return new DefaultDataBufferFactory().wrap(audioBytes);
+								  });
+	}
+}

--- a/src/main/java/com/newworld/saegil/simulator/controller/TextToSpeechController.java
+++ b/src/main/java/com/newworld/saegil/simulator/controller/TextToSpeechController.java
@@ -25,7 +25,7 @@ public class TextToSpeechController {
 
 	@PostMapping(value = "/stream", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
 	public Flux<DataBuffer> streamAudio(@RequestBody TextToSpeechRequest request) {
-		return textToSpeechService.streamSpeech(request.getText())
+		return textToSpeechService.streamSpeech(request.text())
 								  .map(response -> {
 									  byte[] audioBytes = response.getResult().getOutput();
 									  return new DefaultDataBufferFactory().wrap(audioBytes);

--- a/src/main/java/com/newworld/saegil/simulator/controller/TextToSpeechController.java
+++ b/src/main/java/com/newworld/saegil/simulator/controller/TextToSpeechController.java
@@ -17,18 +17,18 @@ import reactor.core.publisher.Flux;
 @RequestMapping("/api/v1/tts")
 public class TextToSpeechController {
 
-	private final TextToSpeechService textToSpeechService;
+    private final TextToSpeechService textToSpeechService;
 
-	public TextToSpeechController(TextToSpeechService textToSpeechService) {
-		this.textToSpeechService = textToSpeechService;
-	}
+    public TextToSpeechController(TextToSpeechService textToSpeechService) {
+        this.textToSpeechService = textToSpeechService;
+    }
 
-	@PostMapping(value = "/stream", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-	public Flux<DataBuffer> streamAudio(@RequestBody TextToSpeechRequest request) {
-		return textToSpeechService.streamSpeech(request.text())
-								  .map(response -> {
-									  byte[] audioBytes = response.getResult().getOutput();
-									  return new DefaultDataBufferFactory().wrap(audioBytes);
-								  });
-	}
+    @PostMapping(value = "/stream", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public Flux<DataBuffer> streamAudio(@RequestBody TextToSpeechRequest request) {
+        return textToSpeechService.streamSpeech(request.text())
+                                  .map(response -> {
+                                      byte[] audioBytes = response.getResult().getOutput();
+                                      return new DefaultDataBufferFactory().wrap(audioBytes);
+                                  });
+    }
 }

--- a/src/main/java/com/newworld/saegil/simulator/dto/TextToSpeechRequest.java
+++ b/src/main/java/com/newworld/saegil/simulator/dto/TextToSpeechRequest.java
@@ -1,0 +1,22 @@
+package com.newworld.saegil.simulator.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * DTO class for text-to-speech request
+ */
+@Setter
+@Getter
+public class TextToSpeechRequest {
+	private String text;
+
+	// Default constructor for JSON deserialization
+	public TextToSpeechRequest() {
+	}
+
+	public TextToSpeechRequest(String text) {
+		this.text = text;
+	}
+
+}

--- a/src/main/java/com/newworld/saegil/simulator/dto/TextToSpeechRequest.java
+++ b/src/main/java/com/newworld/saegil/simulator/dto/TextToSpeechRequest.java
@@ -1,22 +1,4 @@
 package com.newworld.saegil.simulator.dto;
 
-import lombok.Getter;
-import lombok.Setter;
-
-/**
- * DTO class for text-to-speech request
- */
-@Setter
-@Getter
-public class TextToSpeechRequest {
-	private String text;
-
-	// Default constructor for JSON deserialization
-	public TextToSpeechRequest() {
-	}
-
-	public TextToSpeechRequest(String text) {
-		this.text = text;
-	}
-
+public record TextToSpeechRequest(String text) {
 }

--- a/src/main/java/com/newworld/saegil/simulator/service/TextToSpeechService.java
+++ b/src/main/java/com/newworld/saegil/simulator/service/TextToSpeechService.java
@@ -10,14 +10,14 @@ import reactor.core.publisher.Flux;
 @Service
 public class TextToSpeechService {
 
-	private final OpenAiAudioSpeechModel openAiAudioSpeechModel;
+    private final OpenAiAudioSpeechModel openAiAudioSpeechModel;
 
-	public TextToSpeechService(OpenAiAudioSpeechModel openAiAudioSpeechModel) {
-		this.openAiAudioSpeechModel = openAiAudioSpeechModel;
-	}
+    public TextToSpeechService(OpenAiAudioSpeechModel openAiAudioSpeechModel) {
+        this.openAiAudioSpeechModel = openAiAudioSpeechModel;
+    }
 
-	public Flux<SpeechResponse> streamSpeech(String text) {
-		SpeechPrompt speechPrompt = new SpeechPrompt(text);
-		return openAiAudioSpeechModel.stream(speechPrompt);
-	}
+    public Flux<SpeechResponse> streamSpeech(String text) {
+        SpeechPrompt speechPrompt = new SpeechPrompt(text);
+        return openAiAudioSpeechModel.stream(speechPrompt);
+    }
 }

--- a/src/main/java/com/newworld/saegil/simulator/service/TextToSpeechService.java
+++ b/src/main/java/com/newworld/saegil/simulator/service/TextToSpeechService.java
@@ -17,6 +17,7 @@ public class TextToSpeechService {
 	}
 
 	public Flux<SpeechResponse> streamSpeech(String text) {
-		return openAiAudioSpeechModel.stream(new SpeechPrompt(text));
+		SpeechPrompt speechPrompt = new SpeechPrompt(text);
+		return openAiAudioSpeechModel.stream(speechPrompt);
 	}
 }

--- a/src/main/java/com/newworld/saegil/simulator/service/TextToSpeechService.java
+++ b/src/main/java/com/newworld/saegil/simulator/service/TextToSpeechService.java
@@ -1,0 +1,22 @@
+package com.newworld.saegil.simulator.service;
+
+import org.springframework.ai.openai.OpenAiAudioSpeechModel;
+import org.springframework.ai.openai.audio.speech.SpeechPrompt;
+import org.springframework.ai.openai.audio.speech.SpeechResponse;
+import org.springframework.stereotype.Service;
+
+import reactor.core.publisher.Flux;
+
+@Service
+public class TextToSpeechService {
+
+	private final OpenAiAudioSpeechModel openAiAudioSpeechModel;
+
+	public TextToSpeechService(OpenAiAudioSpeechModel openAiAudioSpeechModel) {
+		this.openAiAudioSpeechModel = openAiAudioSpeechModel;
+	}
+
+	public Flux<SpeechResponse> streamSpeech(String text) {
+		return openAiAudioSpeechModel.stream(new SpeechPrompt(text));
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,10 +14,5 @@ spring:
   ai:
     openai:
       api-key: ${OPENAI_API_KEY}
-      model: gpt-4o
-      chat:
-        options:
-          temperature: 0.7
-          max-tokens: 2000
 server:
   port: 8080

--- a/src/main/resources/static/tts-file.html
+++ b/src/main/resources/static/tts-file.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Text-to-Speech 실험 웹앱</title>
+</head>
+<body>
+<h1>Text-to-Speech 테스트</h1>
+<textarea cols="50" id="textInput" placeholder="변환할 텍스트를 입력하세요" rows="5"></textarea>
+<br>
+<button id="sendButton">전송</button>
+<br><br>
+<audio controls id="audioPlayer"></audio>
+
+<script>
+    document.getElementById('sendButton').addEventListener('click', async function () {
+        const text = document.getElementById('textInput').value;
+        const requestBody = {text: text};
+
+        try {
+            const response = await fetch('/api/v1/tts/stream', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(requestBody)
+            });
+
+            if (!response.ok) {
+                throw new Error('서버 오류: ' + response.status);
+            }
+
+            // 바이너리 데이터(오디오 스트림) 처리
+            const audioBlob = await response.blob();
+            const audioUrl = URL.createObjectURL(audioBlob);
+            const audioPlayer = document.getElementById('audioPlayer');
+            audioPlayer.src = audioUrl;
+            audioPlayer.play();
+        } catch (error) {
+            console.error('오류 발생:', error);
+        }
+    });
+</script>
+</body>
+</html>

--- a/src/test/java/com/newworld/saegil/SaegilApplicationTests.java
+++ b/src/test/java/com/newworld/saegil/SaegilApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class SaegilApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }


### PR DESCRIPTION
# OpenAI Controller Guide

## curl 명령어로 TextToSpeech API 요청하기

TextToSpeech API를 curl 명령어로 요청하는 방법은 다음과 같습니다:

```bash
curl -X POST \
  http://localhost:8080/api/v1/tts/stream \
  -H 'Content-Type: application/json' \
  -d '{"text":"안녕하세요, 반갑습니다. 새길팀 화이팅!! 이거 쉽지는 않겠지만 우리 한 번 열심히 해봐요!"}' \
  --output speech.mp3
```

### 명령어 설명

- `-X POST`: HTTP POST 메소드를 사용합니다.
- `http://localhost:8080/api/v1/tts/stream`: 요청할 API 엔드포인트 URL입니다.
- `-H 'Content-Type: application/json'`: 요청 헤더에 Content-Type을 JSON으로 지정합니다.
- `-d '{"text":"안녕하세요, 반갑습니다."}'`: JSON 형식의 요청 본문을 지정합니다. 한국어 텍스트를 포함할 수 있습니다.
- `--output speech.mp3`: 응답으로 받은 오디오 데이터를 speech.mp3 파일로 저장합니다.

### 주의사항

- 서버가 로컬에서 실행 중이어야 합니다 (포트 8080).
- 환경 변수 `OPENAI_API_KEY`가 설정되어 있어야 합니다 (application-local.yml 설정 참조).
- 응답은 MP3 형식의 오디오 파일로 저장됩니다.


### 커밋 메모

- LiveStream이 지원되게 WebFlux로 구현했습니다.
- LiveStreaming을 지원하는 테스터가 있어야 할 듯 합니다.
- Simulator README를 확인해보면 curl 커맨드 사용방법을 기재했습니다.