### PR TITLE
feat: 사용자 조회 기능 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/exception/CustomException.java
+++ b/src/main/java/com/newworld/saegil/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.newworld.saegil.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+
+    public CustomException(final String message, final HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/newworld/saegil/exception/ExceptionResponse.java
+++ b/src/main/java/com/newworld/saegil/exception/ExceptionResponse.java
@@ -1,0 +1,4 @@
+package com.newworld.saegil.exception;
+
+public record ExceptionResponse(String message) {
+}

--- a/src/main/java/com/newworld/saegil/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/newworld/saegil/exception/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+package com.newworld.saegil.exception;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.reactive.resource.NoResourceFoundException;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    private static final String LOG_MESSAGE_FORMAT = "%s : %s";
+
+    private final Log logger = LogFactory.getLog(this.getClass());
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleExceptionInternal(
+            final Exception ex
+    ) {
+        logger.error(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()), ex);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                             .body(new ExceptionResponse(ex.getMessage() == null ? "Internal Server Error" : ex.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ExceptionResponse> handleIllegalArgumentException(
+            final IllegalArgumentException ex
+    ) {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .body(new ExceptionResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleNoResourceFoundException(
+            final NoResourceFoundException ex
+    ) {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                             .body(new ExceptionResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ExceptionResponse> handleMethodArgumentNotValid(
+            final MethodArgumentNotValidException ex
+    ) {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
+
+        final String message = ex.getFieldErrors().stream()
+                                 .map(fieldError -> fieldError.getDefaultMessage())
+                                 .collect(Collectors.joining(", "));
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .body(new ExceptionResponse(message));
+    }
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionResponse> handleCustomException(
+            final CustomException ex
+    ) {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
+
+        return ResponseEntity.status(ex.getHttpStatus())
+                             .body(new ExceptionResponse(ex.getMessage()));
+    }
+}

--- a/src/main/java/com/newworld/saegil/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/newworld/saegil/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.exception;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpStatus;
@@ -11,6 +12,7 @@ import org.springframework.web.reactive.resource.NoResourceFoundException;
 
 import java.util.stream.Collectors;
 
+@Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     private static final String LOG_MESSAGE_FORMAT = "%s : %s";

--- a/src/main/java/com/newworld/saegil/exception/UserNotFoundException.java
+++ b/src/main/java/com/newworld/saegil/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.newworld.saegil.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserNotFoundException extends CustomException {
+
+    public UserNotFoundException(final String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/newworld/saegil/user/controller/ReadUserResponse.java
+++ b/src/main/java/com/newworld/saegil/user/controller/ReadUserResponse.java
@@ -1,0 +1,20 @@
+package com.newworld.saegil.user.controller;
+
+import com.newworld.saegil.user.service.UserDto;
+
+public record ReadUserResponse(
+        Long id,
+        String name,
+        String email,
+        String profileImageUrl
+) {
+
+    public static ReadUserResponse from(final UserDto userDto) {
+        return new ReadUserResponse(
+                userDto.id(),
+                userDto.name(),
+                userDto.email(),
+                userDto.profileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/user/controller/UserController.java
+++ b/src/main/java/com/newworld/saegil/user/controller/UserController.java
@@ -3,7 +3,9 @@ package com.newworld.saegil.user.controller;
 import com.newworld.saegil.configuration.SwaggerConfiguration;
 import com.newworld.saegil.user.service.UserDto;
 import com.newworld.saegil.user.service.UserService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,6 +34,7 @@ public class UserController {
     )
     @ApiResponse(responseCode = "200", description = "유저 본인 정보 조회 성공")
     public ResponseEntity<ReadUserResponse> readUserInfo(
+            @Parameter(description = "Bearer {accessToken}", required = true)
             @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken
     ) {
         // TODO: 유저 정보 조회 기능 개발 후 삭제
@@ -43,7 +46,7 @@ public class UserController {
         ));
     }
 
-    // TODO: 인증된 사용자 정보로 조회하는 API로 변경
+    @Hidden
     @GetMapping("/{id}")
     public ResponseEntity<ReadUserResponse> readById(@PathVariable final Long id) {
         final UserDto userDto = userService.readById(id);

--- a/src/main/java/com/newworld/saegil/user/controller/UserController.java
+++ b/src/main/java/com/newworld/saegil/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.newworld.saegil.user.controller;
+
+import com.newworld.saegil.user.service.UserDto;
+import com.newworld.saegil.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    // TODO: 인증된 사용자 정보로 조회하는 API로 변경
+    @GetMapping("/{id}")
+    public ResponseEntity<ReadUserResponse> readById(@PathVariable final Long id) {
+        final UserDto userDto = userService.readById(id);
+        final ReadUserResponse response = ReadUserResponse.from(userDto);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/newworld/saegil/user/domain/InvalidUserException.java
+++ b/src/main/java/com/newworld/saegil/user/domain/InvalidUserException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.user.domain;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidUserException extends CustomException {
+
+    public InvalidUserException(final String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/newworld/saegil/user/domain/User.java
+++ b/src/main/java/com/newworld/saegil/user/domain/User.java
@@ -1,0 +1,54 @@
+package com.newworld.saegil.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+@ToString(of = {"id", "name"})
+@Table(name = "users")
+public class User {
+
+    private static final int MAX_NAME_LENGTH = 20;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = MAX_NAME_LENGTH)
+    private String name;
+
+    @Column
+    private String email;
+
+    @Column
+    private String profileImageUrl;
+
+    public User(final String name, final String email, final String profileImageUrl) {
+        validateName(name);
+        this.name = name;
+        this.email = email;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    private void validateName(final String name) {
+        if (name == null || name.isBlank()) {
+            throw new InvalidUserException("이름은 필수입니다.");
+        }
+
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new InvalidUserException("이름은 최대 " + MAX_NAME_LENGTH + "자까지 가능합니다.");
+        }
+    }
+}

--- a/src/main/java/com/newworld/saegil/user/repository/UserRepository.java
+++ b/src/main/java/com/newworld/saegil/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.newworld.saegil.user.repository;
+
+import com.newworld.saegil.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/newworld/saegil/user/service/UserDto.java
+++ b/src/main/java/com/newworld/saegil/user/service/UserDto.java
@@ -1,0 +1,20 @@
+package com.newworld.saegil.user.service;
+
+import com.newworld.saegil.user.domain.User;
+
+public record UserDto(
+        Long id,
+        String name,
+        String email,
+        String profileImageUrl
+) {
+
+    public static UserDto from(final User user) {
+        return new UserDto(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/user/service/UserService.java
+++ b/src/main/java/com/newworld/saegil/user/service/UserService.java
@@ -1,0 +1,23 @@
+package com.newworld.saegil.user.service;
+
+import com.newworld.saegil.exception.UserNotFoundException;
+import com.newworld.saegil.user.domain.User;
+import com.newworld.saegil.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserDto readById(final Long userId) {
+        final User findUser = userRepository.findById(userId)
+                                            .orElseThrow(() -> new UserNotFoundException("사용자가 존재하지 않습니다."));
+
+        return UserDto.from(findUser);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,3 +16,6 @@ spring:
       api-key: ${OPENAI_API_KEY}
 server:
   port: 8080
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html

--- a/src/test/java/com/newworld/saegil/user/domain/UserTest.java
+++ b/src/test/java/com/newworld/saegil/user/domain/UserTest.java
@@ -1,0 +1,74 @@
+package com.newworld.saegil.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UserTest {
+
+    @Nested
+    @DisplayName("User 생성 시")
+    class Describe_createUser {
+
+        private final String validEmail = "hong@example.com";
+        private final String validProfileImageUrl = "https://example.com/profile.png";
+
+        @Nested
+        @DisplayName("정상적인 입력이면")
+        class Context_with_valid_input {
+
+            private final String validName = "홍길동";
+
+            @Test
+            void 예외가_발생하지_않는다() {
+                assertThatCode(() -> new User(validName, validEmail, validProfileImageUrl))
+                        .doesNotThrowAnyException();
+            }
+        }
+
+        @Nested
+        @DisplayName("이름이")
+        class Context_with_invalid_name {
+
+            private final String nullName = null;
+            private final String emptyName = "";
+            private final String blankName = "   ";
+            private final String longName = "가".repeat(21);
+
+            @Test
+            void null이면_예외가_발생한다() {
+                assertThatThrownBy(() -> new User(nullName, validEmail, validProfileImageUrl))
+                        .isInstanceOf(InvalidUserException.class)
+                        .hasMessageContaining("이름은 필수입니다.");
+            }
+
+            @Test
+            void 비어있으면_예외가_발생한다() {
+                assertThatThrownBy(() -> new User(emptyName, validEmail, validProfileImageUrl))
+                        .isInstanceOf(InvalidUserException.class)
+                        .hasMessageContaining("이름은 필수입니다.");
+            }
+
+            @Test
+            void 공백이면_예외가_발생한다() {
+                assertThatThrownBy(() -> new User(blankName, validEmail, validProfileImageUrl))
+                        .isInstanceOf(InvalidUserException.class)
+                        .hasMessageContaining("이름은 필수입니다.");
+            }
+
+            @Test
+            void 너무_길면_예외가_발생한다() {
+                assertThatThrownBy(() -> new User(longName, validEmail, validProfileImageUrl))
+                        .isInstanceOf(InvalidUserException.class)
+                        .hasMessageContaining("이름은 최대 20자까지 가능합니다.");
+            }
+        }
+    }
+}

--- a/src/test/java/com/newworld/saegil/user/service/UserServiceTest.java
+++ b/src/test/java/com/newworld/saegil/user/service/UserServiceTest.java
@@ -1,0 +1,79 @@
+package com.newworld.saegil.user.service;
+
+import com.newworld.saegil.exception.UserNotFoundException;
+import com.newworld.saegil.user.domain.User;
+import com.newworld.saegil.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Nested
+    @DisplayName("ID에 해당하는 사용자를 조회하는 메서드에")
+    class Describe_readById {
+
+        @Nested
+        @DisplayName("존재하는 사용자 ID가 주어지면")
+        class Context_with_existing_user {
+
+            @Test
+            void 사용자_정보를_반환한다() {
+                // given
+                final User savedUser = userRepository.save(new User("홍길동", "hong@example.com", "https://example.com/profile.png"));
+
+                entityManager.flush();
+                entityManager.clear();
+
+                // when
+                final UserDto actual = userService.readById(savedUser.getId());
+
+                // then
+                SoftAssertions.assertSoftly(softAssertions -> {
+                    softAssertions.assertThat(actual.id()).isEqualTo(savedUser.getId());
+                    softAssertions.assertThat(actual.name()).isEqualTo(savedUser.getName());
+                    softAssertions.assertThat(actual.email()).isEqualTo(savedUser.getEmail());
+                    softAssertions.assertThat(actual.profileImageUrl()).isEqualTo(savedUser.getProfileImageUrl());
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 사용자 ID가 주어지면")
+        class Context_with_nonexistent_user {
+
+            @Test
+            void UserNotFoundException이_발생한다() {
+                // given
+                final Long invalidUserId = -999L;
+
+                // when & then
+                assertThatThrownBy(() -> userService.readById(invalidUserId))
+                        .isInstanceOf(UserNotFoundException.class)
+                        .hasMessageContaining("사용자가 존재하지 않습니다.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 설명
- 커밋 깨끗하게 해놔서 만약 한 번에 이해하기 어렵다면 커밋별로 보셔도 됩니다.
- `GET /api/v1/users/{id}` API는 현재 필요는 없는데 이해를 위해 넣었습니다. 추후 인증 로직 구현 후 본인 정보 조회 api로 수정할 예정입니다.
- 테스트 코드에는 저번에 이야기 한 DCI 패턴과 assertj 라이브러리를 사용했습니다.
- 패키지 구조 및 코드 스타일 위주로 봐주시면 됩니다. (앞으로 추가할 api도 이 pr에서 결정되는 구조를 따라갈 예정)