### PR TITLE
feat: 카카오 소셜 로그인 기능 구현

### DIFF
--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -1,12 +1,15 @@
 package com.newworld.saegil.authentication.controller;
 
+import com.newworld.saegil.authentication.service.AuthenticationService;
 import com.newworld.saegil.configuration.SwaggerConfiguration;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,12 +20,36 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api/v1/oauth2")
 @RequiredArgsConstructor
 @Tag(name = "Authentication", description = "인증 API")
 public class AuthenticationController {
+
+    private final AuthenticationService authenticationService;
+
+    @GetMapping("/{oauth2Type}")
+    @Operation(
+            summary = "OAuth 2.0 로그인 페이지로 redirect",
+            description = """
+                    OAuth 2.0 로그인 페이지로 redirect합니다.\n
+                    로그인 이후 redirect 되는 url의 `code` query parameter에 Authorization code가 포함되어 있습니다.
+                    """
+    )
+    @ApiResponse(responseCode = "302", description = "OAuth 2.0 로그인 페이지로 redirect 성공")
+    public ResponseEntity<Void> redirectAuthCodeRequestUrl(
+            @Parameter(description = "OAuth 2.0 Type (대소문자 상관 없음)", example = "KAKAO")
+            @PathVariable final String oauth2Type
+    ) {
+        final String redirectUrl = authenticationService.getAuthCodeRequestUrl(oauth2Type);
+
+        return ResponseEntity
+                .status(HttpStatus.FOUND)
+                .location(URI.create(redirectUrl))
+                .build();
+    }
 
     @PostMapping("/login/{oauth2Type}")
     @Operation(

--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -1,6 +1,7 @@
 package com.newworld.saegil.authentication.controller;
 
 import com.newworld.saegil.authentication.service.AuthenticationService;
+import com.newworld.saegil.authentication.service.LoginResult;
 import com.newworld.saegil.configuration.SwaggerConfiguration;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 import java.net.URI;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/v1/oauth2")
@@ -58,10 +60,18 @@ public class AuthenticationController {
     )
     @ApiResponse(responseCode = "200", description = "로그인 성공")
     public ResponseEntity<LoginInformationResponse> login(
+            @Parameter(description = "OAuth 2.0 Type (대소문자 상관 없음)", example = "KAKAO")
             @PathVariable final String oauth2Type,
             @RequestBody @Valid final LoginRequest request
     ) {
-        return null;
+        final LoginResult loginResult = authenticationService.login(
+                oauth2Type,
+                request.authorizationCode(),
+                LocalDateTime.now()
+        );
+        final LoginInformationResponse response = LoginInformationResponse.from(loginResult);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/newworld/saegil/authentication/controller/LoginInformationResponse.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/LoginInformationResponse.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.authentication.controller;
 
+import com.newworld.saegil.authentication.service.LoginResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LoginInformationResponse(
@@ -10,4 +11,11 @@ public record LoginInformationResponse(
         @Schema(description = "서비스 Refresh Token", example = "Bearer refresh-token-opqrstuvwxyz")
         String refreshToken
 ) {
+
+    public static LoginInformationResponse from(final LoginResult loginResult) {
+        return new LoginInformationResponse(
+                loginResult.accessToken(),
+                loginResult.refreshToken()
+        );
+    }
 }

--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
@@ -4,4 +4,5 @@ public interface OAuth2Handler {
 
     OAuth2Type getSupportingOAuth2Type();
     String provideAuthCodeRequestUrl();
+    String getOAuth2AccessToken(final String authorizationCode);
 }

--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
@@ -2,5 +2,6 @@ package com.newworld.saegil.authentication.domain;
 
 public interface OAuth2Handler {
 
+    OAuth2Type getSupportingOAuth2Type();
     String provideAuthCodeRequestUrl();
 }

--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
@@ -1,0 +1,6 @@
+package com.newworld.saegil.authentication.domain;
+
+public interface OAuth2Handler {
+
+    String provideAuthCodeRequestUrl();
+}

--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
@@ -5,4 +5,5 @@ public interface OAuth2Handler {
     OAuth2Type getSupportingOAuth2Type();
     String provideAuthCodeRequestUrl();
     String getOAuth2AccessToken(final String authorizationCode);
+    OAuth2UserInfo getUserInfo(final String accessToken);
 }

--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2HandlerComposite.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2HandlerComposite.java
@@ -1,0 +1,30 @@
+package com.newworld.saegil.authentication.domain;
+
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class OAuth2HandlerComposite {
+
+    private final Map<OAuth2Type, OAuth2Handler> handlerMappings;
+
+    public OAuth2HandlerComposite(final Set<OAuth2Handler> handlers) {
+        this.handlerMappings = new EnumMap<>(OAuth2Type.class);
+        for (final OAuth2Handler handler : handlers) {
+            final OAuth2Type supportingOAuth2Type = handler.getSupportingOAuth2Type();
+            handlerMappings.put(supportingOAuth2Type, handler);
+        }
+    }
+
+    public OAuth2Handler findHandler(final OAuth2Type oauth2Type) {
+        final OAuth2Handler handler = handlerMappings.get(oauth2Type);
+        if (handler == null) {
+            throw new UnsupportedOAuth2LoginException("지원하는 소셜 로그인 기능이 아닙니다.");
+        }
+
+        return handler;
+    }
+}

--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Type.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Type.java
@@ -1,0 +1,17 @@
+package com.newworld.saegil.authentication.domain;
+
+public enum OAuth2Type {
+
+    KAKAO,
+    ;
+
+    public static OAuth2Type from(final String typeName) {
+        for (final OAuth2Type oauth2Type : values()) {
+            if (oauth2Type.name().equalsIgnoreCase(typeName)) {
+                return oauth2Type;
+            }
+        }
+
+        throw new UnsupportedOAuth2LoginException(typeName + "은(는) 지원하는 OAuth2 타입이 아닙니다.");
+    }
+}

--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2UserInfo.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2UserInfo.java
@@ -1,0 +1,9 @@
+package com.newworld.saegil.authentication.domain;
+
+public record OAuth2UserInfo(
+        String oauth2Id,
+        OAuth2Type oauth2Type,
+        String nickname,
+        String profileImageUrl
+) {
+}

--- a/src/main/java/com/newworld/saegil/authentication/domain/PrivateClaims.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/PrivateClaims.java
@@ -1,0 +1,22 @@
+package com.newworld.saegil.authentication.domain;
+
+import io.jsonwebtoken.Claims;
+
+import java.util.Map;
+
+public record PrivateClaims(Long userId) {
+
+    private static final String USER_ID_KEY_NAME = "userId";
+
+    public static PrivateClaims from(final Claims claims) {
+        final Long userId = claims.get(USER_ID_KEY_NAME, Long.class);
+
+        return new PrivateClaims(userId);
+    }
+
+    public Map<String, Object> toMap() {
+        return Map.of(
+                USER_ID_KEY_NAME, userId
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/authentication/domain/UnsupportedOAuth2LoginException.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/UnsupportedOAuth2LoginException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.authentication.domain;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class UnsupportedOAuth2LoginException extends CustomException {
+
+    public UnsupportedOAuth2LoginException(final String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -3,9 +3,17 @@ package com.newworld.saegil.authentication.service;
 import com.newworld.saegil.authentication.domain.OAuth2Handler;
 import com.newworld.saegil.authentication.domain.OAuth2HandlerComposite;
 import com.newworld.saegil.authentication.domain.OAuth2Type;
+import com.newworld.saegil.authentication.domain.OAuth2UserInfo;
+import com.newworld.saegil.authentication.domain.PrivateClaims;
+import com.newworld.saegil.authentication.domain.Token;
+import com.newworld.saegil.authentication.domain.TokenProcessor;
+import com.newworld.saegil.user.domain.User;
+import com.newworld.saegil.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @Transactional
@@ -13,11 +21,50 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthenticationService {
 
     private final OAuth2HandlerComposite oauth2HandlerComposite;
+    private final TokenProcessor tokenProcessor;
+    private final UserRepository userRepository;
 
     public String getAuthCodeRequestUrl(final String oauth2TypeName) {
         final OAuth2Type oauth2Type = OAuth2Type.from(oauth2TypeName);
         final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2Type);
 
         return oauth2Handler.provideAuthCodeRequestUrl();
+    }
+
+    public LoginResult login(
+            final String oauth2TypeName,
+            final String authorizationCode,
+            final LocalDateTime requestTime
+    ) {
+        final OAuth2UserInfo oauth2UserInfo = fetchOAuth2UserInfo(oauth2TypeName, authorizationCode);
+        final User user = findOrPersistUser(oauth2UserInfo);
+        final PrivateClaims privateClaims = new PrivateClaims(user.getId());
+        final Token token = tokenProcessor.generateToken(requestTime, privateClaims.toMap());
+
+        return new LoginResult(user.getId(), token.accessToken(), token.refreshToken());
+    }
+
+    private OAuth2UserInfo fetchOAuth2UserInfo(final String oauth2TypeName, final String authorizationCode) {
+        final OAuth2Type oauth2Type = OAuth2Type.from(oauth2TypeName);
+        final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2Type);
+        final String oauth2AccessToken = oauth2Handler.getOAuth2AccessToken(authorizationCode);
+
+        return oauth2Handler.getUserInfo(oauth2AccessToken);
+    }
+
+    private User findOrPersistUser(final OAuth2UserInfo oauth2UserInfo) {
+        return userRepository.findByOauth2IdAndOauth2Type(
+                oauth2UserInfo.oauth2Id(),
+                oauth2UserInfo.oauth2Type()
+        ).orElseGet(() -> {
+            final User newUser = new User(
+                    oauth2UserInfo.nickname(),
+                    oauth2UserInfo.profileImageUrl(),
+                    oauth2UserInfo.oauth2Id(),
+                    oauth2UserInfo.oauth2Type()
+            );
+
+            return userRepository.save(newUser);
+        });
     }
 }

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -1,0 +1,23 @@
+package com.newworld.saegil.authentication.service;
+
+import com.newworld.saegil.authentication.domain.OAuth2Handler;
+import com.newworld.saegil.authentication.domain.OAuth2HandlerComposite;
+import com.newworld.saegil.authentication.domain.OAuth2Type;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthenticationService {
+
+    private final OAuth2HandlerComposite oauth2HandlerComposite;
+
+    public String getAuthCodeRequestUrl(final String oauth2TypeName) {
+        final OAuth2Type oauth2Type = OAuth2Type.from(oauth2TypeName);
+        final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2Type);
+
+        return oauth2Handler.provideAuthCodeRequestUrl();
+    }
+}

--- a/src/main/java/com/newworld/saegil/authentication/service/LoginResult.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/LoginResult.java
@@ -1,0 +1,8 @@
+package com.newworld.saegil.authentication.service;
+
+public record LoginResult(
+        Long id,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/newworld/saegil/configuration/PropertiesConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/PropertiesConfiguration.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.configuration;
+
+import com.newworld.saegil.security.jwt.JwtProperties;
+import com.newworld.saegil.security.oauth2.KakaoOAuth2Properties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({JwtProperties.class, KakaoOAuth2Properties.class})
+public class PropertiesConfiguration {
+}

--- a/src/main/java/com/newworld/saegil/configuration/PropertiesConfiguration.kt
+++ b/src/main/java/com/newworld/saegil/configuration/PropertiesConfiguration.kt
@@ -1,9 +1,0 @@
-package com.newworld.saegil.configuration
-
-import com.newworld.saegil.security.jwt.JwtProperties
-import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.context.annotation.Configuration
-
-@Configuration
-@EnableConfigurationProperties(JwtProperties::class)
-class PropertiesConfiguration

--- a/src/main/java/com/newworld/saegil/configuration/RestTemplateConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/RestTemplateConfiguration.java
@@ -1,0 +1,14 @@
+package com.newworld.saegil.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Handler.java
+++ b/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Handler.java
@@ -1,0 +1,24 @@
+package com.newworld.saegil.security.oauth2;
+
+import com.newworld.saegil.authentication.domain.OAuth2Handler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuth2Handler implements OAuth2Handler {
+
+    private final KakaoOAuth2Properties kakaoOAuth2Properties;
+
+    @Override
+    public String provideAuthCodeRequestUrl() {
+        return UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("client_id", kakaoOAuth2Properties.clientId())
+                .queryParam("response_type", "code")
+                .queryParam("redirect_uri", kakaoOAuth2Properties.redirectUri())
+                .queryParam("scope", String.join(",", kakaoOAuth2Properties.scope()))
+                .toUriString();
+    }
+}

--- a/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Handler.java
+++ b/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Handler.java
@@ -1,6 +1,7 @@
 package com.newworld.saegil.security.oauth2;
 
 import com.newworld.saegil.authentication.domain.OAuth2Handler;
+import com.newworld.saegil.authentication.domain.OAuth2Type;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -10,6 +11,11 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class KakaoOAuth2Handler implements OAuth2Handler {
 
     private final KakaoOAuth2Properties kakaoOAuth2Properties;
+
+    @Override
+    public OAuth2Type getSupportingOAuth2Type() {
+        return OAuth2Type.KAKAO;
+    }
 
     @Override
     public String provideAuthCodeRequestUrl() {

--- a/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Handler.java
+++ b/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Handler.java
@@ -3,14 +3,25 @@ package com.newworld.saegil.security.oauth2;
 import com.newworld.saegil.authentication.domain.OAuth2Handler;
 import com.newworld.saegil.authentication.domain.OAuth2Type;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class KakaoOAuth2Handler implements OAuth2Handler {
 
     private final KakaoOAuth2Properties kakaoOAuth2Properties;
+    private final RestTemplate restTemplate;
 
     @Override
     public OAuth2Type getSupportingOAuth2Type() {
@@ -26,5 +37,37 @@ public class KakaoOAuth2Handler implements OAuth2Handler {
                 .queryParam("redirect_uri", kakaoOAuth2Properties.redirectUri())
                 .queryParam("scope", String.join(",", kakaoOAuth2Properties.scope()))
                 .toUriString();
+    }
+
+    @Override
+    public String getOAuth2AccessToken(final String authorizationCode) {
+        final HttpEntity<MultiValueMap<String, String>> requestEntity = createAccessTokenRequest(authorizationCode);
+
+        final ResponseEntity<Map> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                requestEntity,
+                Map.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new OAuth2ProcessingException("Kakao Access Token 요청에 실패했습니다.");
+        }
+
+        return response.getBody().get("access_token").toString();
+    }
+
+    private HttpEntity<MultiValueMap<String, String>> createAccessTokenRequest(final String authorizationCode) {
+        final HttpHeaders requestHeaders = new HttpHeaders();
+        requestHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        final MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("grant_type", "authorization_code");
+        requestBody.add("client_id", kakaoOAuth2Properties.clientId());
+        requestBody.add("redirect_uri", kakaoOAuth2Properties.redirectUri());
+        requestBody.add("code", authorizationCode);
+        requestBody.add("client_secret", kakaoOAuth2Properties.clientSecret());
+
+        return new HttpEntity<>(requestBody, requestHeaders);
     }
 }

--- a/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Properties.java
+++ b/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Properties.java
@@ -1,0 +1,14 @@
+package com.newworld.saegil.security.oauth2;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "oauth2.kakao")
+public record KakaoOAuth2Properties(
+        String clientId,
+        String clientSecret,
+        String redirectUri,
+        List<String> scope
+) {
+}

--- a/src/main/java/com/newworld/saegil/security/oauth2/OAuth2ProcessingException.java
+++ b/src/main/java/com/newworld/saegil/security/oauth2/OAuth2ProcessingException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.security.oauth2;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class OAuth2ProcessingException extends CustomException {
+
+    public OAuth2ProcessingException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/newworld/saegil/user/controller/ReadUserResponse.java
+++ b/src/main/java/com/newworld/saegil/user/controller/ReadUserResponse.java
@@ -11,9 +11,6 @@ public record ReadUserResponse(
         @Schema(description = "유저 이름", example = "김주민")
         String name,
 
-        @Schema(description = "유저 이메일", example = "neighbor_kim@naver.com")
-        String email,
-
         @Schema(description = "유저 프로필 이미지 url", example = "https://images.com/asdfasdf")
         String profileImage
 ) {
@@ -22,7 +19,6 @@ public record ReadUserResponse(
         return new ReadUserResponse(
                 userDto.id(),
                 userDto.name(),
-                userDto.email(),
                 userDto.profileImageUrl()
         );
     }

--- a/src/main/java/com/newworld/saegil/user/controller/UserController.java
+++ b/src/main/java/com/newworld/saegil/user/controller/UserController.java
@@ -41,8 +41,7 @@ public class UserController {
         return ResponseEntity.ok(new ReadUserResponse(
                 1L,
                 "김주민",
-                "neighbor_kim@naver.com",
-                "https://i.namu.wiki/i/RYsQTAH1KBL6UhqDOp12H5MEk69vd4WroI0bs-hU5ot2HXsvhkf6zjarDYtSXRy4qVJ3b6ogUhsycLcBbyiiqrlajTNKsoPkKj9w1TuRbbqv8glhW9bHLmpxcirJMHue3Qt22jAeAW3bk6eE4AeekQ.svg"
+                "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg"
         ));
     }
 

--- a/src/main/java/com/newworld/saegil/user/domain/User.java
+++ b/src/main/java/com/newworld/saegil/user/domain/User.java
@@ -1,7 +1,10 @@
 package com.newworld.saegil.user.domain;
 
+import com.newworld.saegil.authentication.domain.OAuth2Type;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,17 +32,22 @@ public class User {
     @Column(length = MAX_NAME_LENGTH)
     private String name;
 
-    @Column
-    private String email;
-
-    @Column
+    @Column(nullable = false)
     private String profileImageUrl;
 
-    public User(final String name, final String email, final String profileImageUrl) {
+    @Column(name = "oauth2_id", nullable = false)
+    private String oauth2Id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "oauth2_type", nullable = false)
+    private OAuth2Type oauth2Type;
+
+    public User(final String name, final String profileImageUrl, final String oauth2Id, final OAuth2Type oauth2Type) {
         validateName(name);
         this.name = name;
-        this.email = email;
         this.profileImageUrl = profileImageUrl;
+        this.oauth2Id = oauth2Id;
+        this.oauth2Type = oauth2Type;
     }
 
     private void validateName(final String name) {

--- a/src/main/java/com/newworld/saegil/user/repository/UserRepository.java
+++ b/src/main/java/com/newworld/saegil/user/repository/UserRepository.java
@@ -1,9 +1,14 @@
 package com.newworld.saegil.user.repository;
 
+import com.newworld.saegil.authentication.domain.OAuth2Type;
 import com.newworld.saegil.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByOauth2IdAndOauth2Type(String oauth2Id, OAuth2Type oauth2Type);
 }

--- a/src/main/java/com/newworld/saegil/user/service/UserDto.java
+++ b/src/main/java/com/newworld/saegil/user/service/UserDto.java
@@ -1,20 +1,23 @@
 package com.newworld.saegil.user.service;
 
+import com.newworld.saegil.authentication.domain.OAuth2Type;
 import com.newworld.saegil.user.domain.User;
 
 public record UserDto(
         Long id,
         String name,
-        String email,
-        String profileImageUrl
+        String profileImageUrl,
+        String oauth2Id,
+        OAuth2Type oauth2Type
 ) {
 
     public static UserDto from(final User user) {
         return new UserDto(
                 user.getId(),
                 user.getName(),
-                user.getEmail(),
-                user.getProfileImageUrl()
+                user.getProfileImageUrl(),
+                user.getOauth2Id(),
+                user.getOauth2Type()
         );
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -25,3 +25,9 @@ token:
     refresh-key: ThisIsLocalRefreshKeyThisIsLocalRefreshKey
     access-expired-hours: 1 # 1시간
     refresh-expired-hours: 336  # 14일
+oauth2:
+  kakao:
+    client_id: ${KAKAO_CLIENT_ID}
+    client_secret: ${KAKAO_CLIENT_SECRET}
+    redirect_uri: ${KAKAO_REDIRECT_URI}
+    scope: ${KAKAO_SCOPE}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,6 +7,13 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+        show_sql: true
+        use_sql_comments: true
+    open-in-view: false
   h2:
     console:
       enabled: true

--- a/src/test/java/com/newworld/saegil/authentication/domain/OAuth2HandlerCompositeTest.java
+++ b/src/test/java/com/newworld/saegil/authentication/domain/OAuth2HandlerCompositeTest.java
@@ -1,0 +1,57 @@
+package com.newworld.saegil.authentication.domain;
+
+import com.newworld.saegil.security.oauth2.KakaoOAuth2Handler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class OAuth2HandlerCompositeTest {
+
+    @Nested
+    @DisplayName("지원하는 OAuth2 핸들러를 찾는 메서드에")
+    class Describe_findHandler {
+
+        @Nested
+        @DisplayName("지원하는 OAuth2 타입을 전달하면")
+        class Context_valid_oauth2_type {
+
+            @Test
+            void 해당_OAuth2_핸들러를_반환한다() {
+                // given
+                final OAuth2Handler kakaoHandler = new KakaoOAuth2Handler(null);
+                final OAuth2HandlerComposite composite = new OAuth2HandlerComposite(Set.of(kakaoHandler));
+
+                // when
+                final OAuth2Handler actual = composite.findHandler(OAuth2Type.KAKAO);
+
+                // then
+                assertThat(actual).isInstanceOf(KakaoOAuth2Handler.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("지원하지 않는 OAuth2 타입을 전달하면")
+        class Context_invalid_oauth2_type {
+
+            @Test
+            void 예외가_발생한다() {
+                // given
+                final OAuth2HandlerComposite emptyComposite = new OAuth2HandlerComposite(Set.of());
+
+                // when & then
+                assertThatThrownBy(() -> emptyComposite.findHandler(OAuth2Type.KAKAO))
+                        .isInstanceOf(UnsupportedOAuth2LoginException.class)
+                        .hasMessage("지원하는 소셜 로그인 기능이 아닙니다.");
+            }
+        }
+    }
+}

--- a/src/test/java/com/newworld/saegil/authentication/domain/OAuth2HandlerCompositeTest.java
+++ b/src/test/java/com/newworld/saegil/authentication/domain/OAuth2HandlerCompositeTest.java
@@ -27,7 +27,7 @@ class OAuth2HandlerCompositeTest {
             @Test
             void 해당_OAuth2_핸들러를_반환한다() {
                 // given
-                final OAuth2Handler kakaoHandler = new KakaoOAuth2Handler(null);
+                final OAuth2Handler kakaoHandler = new KakaoOAuth2Handler(null, null);
                 final OAuth2HandlerComposite composite = new OAuth2HandlerComposite(Set.of(kakaoHandler));
 
                 // when

--- a/src/test/java/com/newworld/saegil/authentication/domain/OAuth2TypeTest.java
+++ b/src/test/java/com/newworld/saegil/authentication/domain/OAuth2TypeTest.java
@@ -1,0 +1,64 @@
+package com.newworld.saegil.authentication.domain;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OAuth2TypeTest {
+
+    @Nested
+    @DisplayName("문자열에 해당하는 OAuth2Type을 찾을 때")
+    class Describe_from {
+
+        @Nested
+        @DisplayName("유효한 타입 이름이 주어지면")
+        class Context_valid_type_name {
+
+            @Test
+            void 대소문자_구분없이_적절한_OAuth2Type을_반환한다() {
+                // given
+                final OAuth2Type expect = OAuth2Type.KAKAO;
+                String upperCaseTypeName = expect.name().toUpperCase();
+                String lowerCaseTypeName = expect.name().toLowerCase();
+
+                // when & then
+                SoftAssertions.assertSoftly(softAssertions -> {
+                    softAssertions.assertThatCode(() -> OAuth2Type.from(upperCaseTypeName))
+                                  .doesNotThrowAnyException();
+
+                    softAssertions.assertThat(OAuth2Type.from(upperCaseTypeName))
+                                  .isEqualTo(expect);
+
+                    softAssertions.assertThatCode(() -> OAuth2Type.from(lowerCaseTypeName))
+                                  .doesNotThrowAnyException();
+
+                    softAssertions.assertThat(OAuth2Type.from(lowerCaseTypeName))
+                                  .isEqualTo(expect);
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("유효하지 않은 타입 이름이 주어지면")
+        class Context_invalid_type_name {
+
+            @Test
+            void 예외가_발생한다() {
+                // given
+                String invalidType = "INVALID";
+
+                // when & then
+                assertThatThrownBy(() -> OAuth2Type.from(invalidType))
+                        .isInstanceOf(UnsupportedOAuth2LoginException.class)
+                        .hasMessage("INVALID은(는) 지원하는 OAuth2 타입이 아닙니다.");
+            }
+        }
+    }
+}

--- a/src/test/java/com/newworld/saegil/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/newworld/saegil/authentication/service/AuthenticationServiceTest.java
@@ -1,0 +1,126 @@
+package com.newworld.saegil.authentication.service;
+
+import com.newworld.saegil.authentication.domain.OAuth2Handler;
+import com.newworld.saegil.authentication.domain.OAuth2HandlerComposite;
+import com.newworld.saegil.authentication.domain.OAuth2Type;
+import com.newworld.saegil.authentication.domain.OAuth2UserInfo;
+import com.newworld.saegil.user.domain.User;
+import com.newworld.saegil.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@Transactional
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AuthenticationServiceTest {
+
+    @Autowired
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private OAuth2HandlerComposite oauth2HandlerComposite;
+
+    @MockitoBean
+    private OAuth2Handler mockOAuth2Handler;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        given(oauth2HandlerComposite.findHandler(any())).willReturn(mockOAuth2Handler);
+    }
+
+    @Nested
+    @DisplayName("로그인 할 때")
+    class Describe_login {
+
+        private static final String 카카오_인증_코드 = "authorization code";
+        private static final String 카카오_액세스_토큰 = "oauth2-access-token";
+        private static final String SERVICE_TOKEN_PREFIX = "Bearer ";
+        private static final OAuth2UserInfo OAUTH2_회원_정보 = new OAuth2UserInfo(
+                "1234567",
+                OAuth2Type.KAKAO,
+                "홍길동",
+                "http://example.com/profile.jpg"
+        );
+
+        @Nested
+        @DisplayName("가입된 사용자가 로그인 한 것이면")
+        class Context_with_existing_user {
+
+            @Test
+            void 바로_access_token과_refresh_token을_발급한다() {
+                // given
+                final User 가입된_유저 = userRepository.save(
+                        new User(
+                                OAUTH2_회원_정보.nickname(),
+                                OAUTH2_회원_정보.profileImageUrl(),
+                                OAUTH2_회원_정보.oauth2Id(),
+                                OAUTH2_회원_정보.oauth2Type()
+                        )
+                );
+                entityManager.flush();
+                entityManager.clear();
+
+                given(mockOAuth2Handler.getOAuth2AccessToken(카카오_인증_코드)).willReturn(카카오_액세스_토큰);
+                given(mockOAuth2Handler.getUserInfo(카카오_액세스_토큰)).willReturn(OAUTH2_회원_정보);
+
+                // when
+                final LoginResult result = authenticationService.login("KAKAO", 카카오_인증_코드, LocalDateTime.now());
+
+                // then
+                SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(result.id()).isEqualTo(가입된_유저.getId());
+                    softly.assertThat(result.accessToken()).startsWith(SERVICE_TOKEN_PREFIX);
+                    softly.assertThat(result.refreshToken()).startsWith(SERVICE_TOKEN_PREFIX);
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("최초로_로그인한_것이면")
+        class Context_with_new_user {
+
+            @Test
+            void 회원가입_후_토큰을_발급하고_정상_응답한다() {
+                // given
+                given(mockOAuth2Handler.getOAuth2AccessToken(카카오_인증_코드)).willReturn(카카오_액세스_토큰);
+                given(mockOAuth2Handler.getUserInfo(카카오_액세스_토큰)).willReturn(OAUTH2_회원_정보);
+
+                // when
+                final LoginResult result = authenticationService.login("KAKAO", 카카오_인증_코드, LocalDateTime.now());
+                entityManager.flush();
+                entityManager.clear();
+
+                // then
+                final User savedUser = userRepository.findById(1L).get();
+
+                SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(result.id()).isEqualTo(savedUser.getId());
+                    softly.assertThat(result.accessToken()).startsWith(SERVICE_TOKEN_PREFIX);
+                    softly.assertThat(result.refreshToken()).startsWith(SERVICE_TOKEN_PREFIX);
+                });
+            }
+        }
+    }
+}

--- a/src/test/java/com/newworld/saegil/security/jwt/JwtTokenProcessorTest.java
+++ b/src/test/java/com/newworld/saegil/security/jwt/JwtTokenProcessorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.Optional;
 
@@ -41,7 +42,11 @@ class JwtTokenProcessorTest {
             Map<String, Object> claims = Map.of(keyName, userId);
 
             // when
-            String actual = jwtProcessor.encode(LocalDateTime.now(), TokenType.ACCESS, claims);
+            String actual = jwtProcessor.encode(
+                    LocalDateTime.now(ZoneId.of("Asia/Seoul")),
+                    TokenType.ACCESS,
+                    claims
+            );
 
             // then
             assertThat(actual).startsWith("Bearer ");
@@ -64,7 +69,11 @@ class JwtTokenProcessorTest {
                 final Long userId = 123L;
                 final TokenType tokenType = TokenType.ACCESS;
                 final Map<String, Object> claims = Map.of(keyName, userId);
-                final String token = jwtProcessor.encode(LocalDateTime.now(), tokenType, claims);
+                final String token = jwtProcessor.encode(
+                        LocalDateTime.now(ZoneId.of("Asia/Seoul")),
+                        tokenType,
+                        claims
+                );
 
                 // when
                 final Optional<Claims> actual = jwtProcessor.decode(tokenType, token);
@@ -129,7 +138,11 @@ class JwtTokenProcessorTest {
                 final String keyName = "userId";
                 final Long userId = 123L;
                 final Map<String, Object> claims = Map.of(keyName, userId);
-                final String encodedToken = jwtProcessor.encode(LocalDateTime.now(), TokenType.ACCESS, claims);
+                final String encodedToken = jwtProcessor.encode(
+                        LocalDateTime.now(ZoneId.of("Asia/Seoul")),
+                        TokenType.ACCESS,
+                        claims
+                );
 
                 // when
                 final Optional<Claims> actual = jwtProcessor.decode(TokenType.ACCESS, encodedToken);

--- a/src/test/java/com/newworld/saegil/user/domain/UserTest.java
+++ b/src/test/java/com/newworld/saegil/user/domain/UserTest.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.user.domain;
 
+import com.newworld.saegil.authentication.domain.OAuth2Type;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -17,8 +18,9 @@ class UserTest {
     @DisplayName("User 생성 시")
     class Describe_createUser {
 
-        private final String validEmail = "hong@example.com";
         private final String validProfileImageUrl = "https://example.com/profile.png";
+        private final String validOAuth2Id = "123456";
+        private final OAuth2Type validOAuth2Type = OAuth2Type.KAKAO;
 
         @Nested
         @DisplayName("정상적인 입력이면")
@@ -28,7 +30,7 @@ class UserTest {
 
             @Test
             void 예외가_발생하지_않는다() {
-                assertThatCode(() -> new User(validName, validEmail, validProfileImageUrl))
+                assertThatCode(() -> new User(validName, validProfileImageUrl, validOAuth2Id, validOAuth2Type))
                         .doesNotThrowAnyException();
             }
         }
@@ -44,28 +46,28 @@ class UserTest {
 
             @Test
             void null이면_예외가_발생한다() {
-                assertThatThrownBy(() -> new User(nullName, validEmail, validProfileImageUrl))
+                assertThatThrownBy(() -> new User(nullName, validProfileImageUrl, validOAuth2Id, validOAuth2Type))
                         .isInstanceOf(InvalidUserException.class)
                         .hasMessageContaining("이름은 필수입니다.");
             }
 
             @Test
             void 비어있으면_예외가_발생한다() {
-                assertThatThrownBy(() -> new User(emptyName, validEmail, validProfileImageUrl))
+                assertThatThrownBy(() -> new User(emptyName, validProfileImageUrl, validOAuth2Id, validOAuth2Type))
                         .isInstanceOf(InvalidUserException.class)
                         .hasMessageContaining("이름은 필수입니다.");
             }
 
             @Test
             void 공백이면_예외가_발생한다() {
-                assertThatThrownBy(() -> new User(blankName, validEmail, validProfileImageUrl))
+                assertThatThrownBy(() -> new User(blankName, validProfileImageUrl, validOAuth2Id, validOAuth2Type))
                         .isInstanceOf(InvalidUserException.class)
                         .hasMessageContaining("이름은 필수입니다.");
             }
 
             @Test
             void 너무_길면_예외가_발생한다() {
-                assertThatThrownBy(() -> new User(longName, validEmail, validProfileImageUrl))
+                assertThatThrownBy(() -> new User(longName, validProfileImageUrl, validOAuth2Id, validOAuth2Type))
                         .isInstanceOf(InvalidUserException.class)
                         .hasMessageContaining("이름은 최대 20자까지 가능합니다.");
             }

--- a/src/test/java/com/newworld/saegil/user/service/UserServiceTest.java
+++ b/src/test/java/com/newworld/saegil/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.user.service;
 
+import com.newworld.saegil.authentication.domain.OAuth2Type;
 import com.newworld.saegil.exception.UserNotFoundException;
 import com.newworld.saegil.user.domain.User;
 import com.newworld.saegil.user.repository.UserRepository;
@@ -42,7 +43,9 @@ class UserServiceTest {
             @Test
             void 사용자_정보를_반환한다() {
                 // given
-                final User savedUser = userRepository.save(new User("홍길동", "hong@example.com", "https://example.com/profile.png"));
+                final User savedUser = userRepository.save(
+                        new User("홍길동", "https://example.com/profile.png", "123456", OAuth2Type.KAKAO)
+                );
 
                 entityManager.flush();
                 entityManager.clear();
@@ -54,7 +57,8 @@ class UserServiceTest {
                 SoftAssertions.assertSoftly(softAssertions -> {
                     softAssertions.assertThat(actual.id()).isEqualTo(savedUser.getId());
                     softAssertions.assertThat(actual.name()).isEqualTo(savedUser.getName());
-                    softAssertions.assertThat(actual.email()).isEqualTo(savedUser.getEmail());
+                    softAssertions.assertThat(actual.oauth2Id()).isEqualTo(savedUser.getOauth2Id());
+                    softAssertions.assertThat(actual.oauth2Type()).isEqualTo(savedUser.getOauth2Type());
                     softAssertions.assertThat(actual.profileImageUrl()).isEqualTo(savedUser.getProfileImageUrl());
                 });
             }


### PR DESCRIPTION
# 설명
- 카카오 로그인에 사용하는 client-id, client-secret, redirect-uri, scope 값은 노션에 적어두었습니다.
- 카카오 로그인만 하기로 했지만 다른 소셜 로그인도 쉽게 추가할 수 있도록 OAuth2Handler를 인터페이스로 두고, KakaoOAuth2Handler가 인터페이스를 구현하도록 설계했습니다. 예를 들어 구글 로그인을 추가하게 된다면 OAuth2Handler 인터페이스를 구현하는 GoogleOAuth2Handler만 추가로 만들면 됩니다.
- 여러 oauth를 지원하는 것을 가정했을 때, 사용자 요청에 따라 어떤 handler를 사용해야할 지 찾아야 합니다. (카카오 로그인인지, 구글 로그인인지 등) 그래서 모든 OAuth2Handler 구현체를 들고 있는 Composite 클래스로 OAuth2HandlerComposite을 두었습니다.

소셜 로그인 대략적인 사이클은 다음과 같습니다.
1. 클라이언트가 서버에게 카카오로그인을 위한 url을 리다이렉트받는다. (`/api/v1/oauth2/kakao`로 요청)
2. 리다이렉트된 카카오 로그인 페이지에서 사용자가 로그인한다.
3. 카카오 서버가 특정 페이지로 리다이렉트시킨다. (백엔드 개발자가 설정한 redirect url (application-local.yml)에 있어요.)
4. 카카오 서버가 리다이렉트시킨 url의 쿼리파라미터에서 authorization code를 추출한다.
5. 해당 authorization code로 백엔드 서버에 로그인 요청한다. (`/api/v1/oauth2/login/kakao`로 요청)
6. 백엔드 서버는 authorization code를 이용해 카카오 서버로부터 access token을 발급받는다.
7. 발급받은 access token으로 카카오 유저 정보를 조회한다. (oauthId, 닉네임, 프로필이미지url)
8. oauthType과 oauthId로 디비에서 사용자를 찾는다.
9. 없다면 사용자를 저장한다.
10. 조회한 사용자(or 새로 저장한 사용자)의 id를 jwt payload에 넣어서 서비스용 access token과 refresh token을 발행한다.
11. 서비스 access token과 refresh token을 클라이언트에게 응답한다. (카카오 access token과 다른 토큰입니다.)
- 모바일과 협업한다면 1~4번은 모바일에서 처리하고 백엔드는 5번부터 처리하면 된다고 어디서 보긴 했는데 어차피 저희 개인적으로 테스트할 때도 필요하고 해서 1번 기능도 그냥 만들어두었어요.