### PR TITLE
refactor: Swagger `@ApiResponse`의 responseCode 값에 상수 사용

### DIFF
--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -3,6 +3,7 @@ package com.newworld.saegil.authentication.controller;
 import com.newworld.saegil.authentication.service.AuthenticationService;
 import com.newworld.saegil.authentication.service.LoginResult;
 import com.newworld.saegil.configuration.SwaggerConfiguration;
+import com.newworld.saegil.global.swagger.ApiResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -40,7 +41,7 @@ public class AuthenticationController {
                     로그인 이후 redirect 되는 url의 `code` query parameter에 Authorization code가 포함되어 있습니다.
                     """
     )
-    @ApiResponse(responseCode = "302", description = "OAuth 2.0 로그인 페이지로 redirect 성공")
+    @ApiResponse(responseCode = ApiResponseCode.FOUND, description = "OAuth 2.0 로그인 페이지로 redirect 성공")
     public ResponseEntity<Void> redirectAuthCodeRequestUrl(
             @Parameter(description = "OAuth 2.0 Type (대소문자 상관 없음)", example = "KAKAO")
             @PathVariable final String oauth2Type
@@ -58,7 +59,7 @@ public class AuthenticationController {
             summary = "OAuth 2.0 로그인",
             description = "OAuth 2.0 Authorization code를 통해 로그인합니다."
     )
-    @ApiResponse(responseCode = "200", description = "로그인 성공")
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "로그인 성공")
     public ResponseEntity<LoginInformationResponse> login(
             @Parameter(description = "OAuth 2.0 Type (대소문자 상관 없음)", example = "KAKAO")
             @PathVariable final String oauth2Type,
@@ -80,7 +81,7 @@ public class AuthenticationController {
             description = "로그아웃합니다.",
             security = @SecurityRequirement(name = SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)
     )
-    @ApiResponse(responseCode = "204", description = "로그아웃 성공")
+    @ApiResponse(responseCode = ApiResponseCode.NO_CONTENT, description = "로그아웃 성공")
     public ResponseEntity<Void> logout(
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
             @RequestBody @Valid final LogoutRequest request
@@ -94,7 +95,7 @@ public class AuthenticationController {
             description = "Access Token의 유효성을 검사합니다.",
             security = @SecurityRequirement(name = SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)
     )
-    @ApiResponse(responseCode = "200", description = "Access Token 유효성 검사 성공")
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "Access Token 유효성 검사 성공")
     public ResponseEntity<ValidateTokenResponse> validateToken(
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken
     ) {
@@ -106,7 +107,7 @@ public class AuthenticationController {
             summary = "새 토큰 발급",
             description = "Refresh Token으로 새로운 Access Token과 Refresh Token을 발급합니다."
     )
-    @ApiResponse(responseCode = "200", description = "새 토큰 발급 성공")
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "새 토큰 발급 성공")
     public ResponseEntity<TokenRefreshResponse> refreshToken(
             @RequestBody @Valid final TokenRefreshRequest request
     ) {
@@ -119,7 +120,7 @@ public class AuthenticationController {
             description = "회원 탈퇴를 진행합니다.",
             security = @SecurityRequirement(name = SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)
     )
-    @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공")
+    @ApiResponse(responseCode = ApiResponseCode.NO_CONTENT, description = "회원 탈퇴 성공")
     public ResponseEntity<Void> withdrawal(
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
             @RequestBody @Valid final WithdrawalRequest request

--- a/src/main/java/com/newworld/saegil/global/swagger/ApiResponseCode.java
+++ b/src/main/java/com/newworld/saegil/global/swagger/ApiResponseCode.java
@@ -1,0 +1,16 @@
+package com.newworld.saegil.global.swagger;
+
+public class ApiResponseCode {
+    public static final String OK = "200";
+    public static final String CREATED = "201";
+    public static final String NO_CONTENT = "204";
+    public static final String FOUND = "302";
+    public static final String BAD_REQUEST = "400";
+    public static final String UNAUTHORIZED = "401";
+    public static final String FORBIDDEN = "403";
+    public static final String NOT_FOUND = "404";
+    public static final String INTERNAL_SERVER_ERROR = "500";
+
+    private ApiResponseCode() {
+    }
+}

--- a/src/main/java/com/newworld/saegil/map/controller/OrganizationController.java
+++ b/src/main/java/com/newworld/saegil/map/controller/OrganizationController.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.map.controller;
 
+import com.newworld.saegil.global.swagger.ApiResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -24,7 +25,7 @@ public class OrganizationController {
             summary = "근처 기관 조회",
             description = "사용자의 현재 위치와 반경을 기준으로 주변 기관을 조회합니다."
     )
-    @ApiResponse(responseCode = "200", description = "근처 기관 조회 성공")
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "근처 기관 조회 성공")
     public ResponseEntity<List<ReadOrganizationResponse>> getNearbyOrganizations(
             @Parameter(description = "현재 위도", example = "37.5326")
             @RequestParam double latitude,

--- a/src/main/java/com/newworld/saegil/notice/controller/NoticeController.java
+++ b/src/main/java/com/newworld/saegil/notice/controller/NoticeController.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.notice.controller;
 
+import com.newworld.saegil.global.swagger.ApiResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -26,7 +27,7 @@ public class NoticeController {
             summary = "공지사항 기관 목록 조회",
             description = "공지사항 기관 목록을 조회합니다."
     )
-    @ApiResponse(responseCode = "200", description = "공지사항 기관 목록 조회 성공")
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "공지사항 기관 목록 조회 성공")
     public ResponseEntity<List<ReadNoticeSourceItemResponse>> readAllSources() {
         List<ReadNoticeSourceItemResponse> sources = new ArrayList<>();
         sources.add(new ReadNoticeSourceItemResponse(1L, "남북하나재단"));
@@ -40,7 +41,7 @@ public class NoticeController {
             summary = "공지사항 목록 조회",
             description = "공지사항 목록 전체 조회, 검색, 필터링이 가능합니다. 무한스크롤 방식으로 lastId를 기준으로 데이터를 가져옵니다."
     )
-    @ApiResponse(responseCode = "200", description = "공지사항 목록 조회 성공")
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "공지사항 목록 조회 성공")
     public ResponseEntity<ReadNoticesResponse> readAll(
             @Parameter(description = "검색어 (필수 x)", example = "채용")
             @RequestParam(required = false) final String query,

--- a/src/main/java/com/newworld/saegil/user/controller/UserController.java
+++ b/src/main/java/com/newworld/saegil/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.newworld.saegil.user.controller;
 
 import com.newworld.saegil.configuration.SwaggerConfiguration;
+import com.newworld.saegil.global.swagger.ApiResponseCode;
 import com.newworld.saegil.user.service.UserDto;
 import com.newworld.saegil.user.service.UserService;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -32,12 +33,12 @@ public class UserController {
             description = "access token을 통해 유저 본인 정보를 조회합니다.",
             security = @SecurityRequirement(name = SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)
     )
-    @ApiResponse(responseCode = "200", description = "유저 본인 정보 조회 성공")
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "유저 본인 정보 조회 성공")
     public ResponseEntity<ReadUserResponse> readUserInfo(
             @Parameter(description = "Bearer {accessToken}", required = true)
             @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken
     ) {
-        // TODO: 유저 정보 조회 기능 개발 후 삭제
+        // TODO: 유저 본인 정보 조회 기능 개발 후 삭제
         return ResponseEntity.ok(new ReadUserResponse(
                 1L,
                 "김주민",
@@ -45,6 +46,7 @@ public class UserController {
         ));
     }
 
+    // TODO: 유저 본인 정보 조회 기능 개발 후 삭제
     @Hidden
     @GetMapping("/{id}")
     public ResponseEntity<ReadUserResponse> readById(@PathVariable final Long id) {


### PR DESCRIPTION
[카카오 로그인 pr에 지웅님이 남겨주신 코멘트](https://github.com/saegil-project/Saegil-Server/pull/11#discussion_r2036326273) 적용했습니다. 

원래는 스프링에서 제공하는 HttpStatus enum 클래스의 값을 사용하려고 했는데 (ex. HttpStatus.OK.value()) `Attribute value must be constant` 에러가 발생하네요. 그래서 상수 클래스 정의해놓고 사용했습니다.

이 pr 머지되면 지웅님 pr에서도 swagger 부분 수정해주세요!