### PR TITLE
feat: 인증/인가 기능 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/authentication/annotation/AuthUser.java
+++ b/src/main/java/com/newworld/saegil/authentication/annotation/AuthUser.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.authentication.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUser {
+}

--- a/src/main/java/com/newworld/saegil/authentication/dto/AuthUserInfo.java
+++ b/src/main/java/com/newworld/saegil/authentication/dto/AuthUserInfo.java
@@ -1,0 +1,6 @@
+package com.newworld.saegil.authentication.dto;
+
+public record AuthUserInfo(
+        Long userId
+) {
+}

--- a/src/main/java/com/newworld/saegil/authentication/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/newworld/saegil/authentication/interceptor/LoginInterceptor.java
@@ -1,0 +1,34 @@
+package com.newworld.saegil.authentication.interceptor;
+
+import com.newworld.saegil.authentication.domain.TokenType;
+import com.newworld.saegil.authentication.service.AuthenticationService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class LoginInterceptor implements HandlerInterceptor {
+
+    private final AuthenticationService authenticationService;
+
+    @Override
+    public boolean preHandle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Object handler
+    ) {
+        String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new LoginRequiredException("로그인이 필요한 기능입니다.");
+        }
+
+        authenticationService.getValidPrivateClaims(TokenType.ACCESS, accessToken);
+
+        return true;
+    }
+}

--- a/src/main/java/com/newworld/saegil/authentication/interceptor/LoginRequiredException.java
+++ b/src/main/java/com/newworld/saegil/authentication/interceptor/LoginRequiredException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.authentication.interceptor;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class LoginRequiredException extends CustomException {
+
+    public LoginRequiredException(final String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/newworld/saegil/authentication/resolver/AuthUserInfoArgumentResolver.java
+++ b/src/main/java/com/newworld/saegil/authentication/resolver/AuthUserInfoArgumentResolver.java
@@ -1,0 +1,49 @@
+package com.newworld.saegil.authentication.resolver;
+
+import com.newworld.saegil.authentication.annotation.AuthUser;
+import com.newworld.saegil.authentication.domain.PrivateClaims;
+import com.newworld.saegil.authentication.domain.TokenProcessor;
+import com.newworld.saegil.authentication.domain.TokenType;
+import com.newworld.saegil.authentication.dto.AuthUserInfo;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserInfoArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final TokenProcessor tokenProcessor;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthUser.class) &&
+                parameter.getParameterType() == AuthUserInfo.class;
+    }
+
+    @Override
+    public Object resolveArgument(
+            @NotNull final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            @NotNull final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
+    ) {
+        final String accessToken = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new IllegalArgumentException("로그인이 필요한 기능입니다.");
+        }
+
+        final Claims claims = tokenProcessor.decode(TokenType.ACCESS, accessToken)
+                                            .orElseThrow(() -> new IllegalArgumentException("유효한 토큰이 아닙니다."));
+        final PrivateClaims privateClaims = PrivateClaims.from(claims);
+
+        return new AuthUserInfo(privateClaims.userId());
+    }
+}

--- a/src/main/java/com/newworld/saegil/authentication/service/NoSuchUserException.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/NoSuchUserException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.authentication.service;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class NoSuchUserException extends CustomException {
+
+    public NoSuchUserException(final String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
@@ -1,0 +1,36 @@
+package com.newworld.saegil.configuration;
+
+import com.newworld.saegil.authentication.interceptor.LoginInterceptor;
+import com.newworld.saegil.authentication.resolver.AuthUserInfoArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfiguration implements WebMvcConfigurer {
+
+    private final LoginInterceptor loginInterceptor;
+    private final AuthUserInfoArgumentResolver authUserInfoArgumentResolver;
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(loginInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/")
+                .excludePathPatterns("/index.html")
+                .excludePathPatterns("/test-llm-proxy.html")
+                .excludePathPatterns("/api/v1/organizations/**")
+                .excludePathPatterns("/api/v1/notices/**")
+                .excludePathPatterns("/api/v1/oauth2/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserInfoArgumentResolver);
+    }
+}

--- a/src/main/java/com/newworld/saegil/user/controller/UserController.java
+++ b/src/main/java/com/newworld/saegil/user/controller/UserController.java
@@ -1,21 +1,19 @@
 package com.newworld.saegil.user.controller;
 
+import com.newworld.saegil.authentication.annotation.AuthUser;
+import com.newworld.saegil.authentication.dto.AuthUserInfo;
 import com.newworld.saegil.configuration.SwaggerConfiguration;
 import com.newworld.saegil.global.swagger.ApiResponseCode;
 import com.newworld.saegil.user.service.UserDto;
 import com.newworld.saegil.user.service.UserService;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,21 +34,9 @@ public class UserController {
     @ApiResponse(responseCode = ApiResponseCode.OK, description = "유저 본인 정보 조회 성공")
     public ResponseEntity<ReadUserResponse> readUserInfo(
             @Parameter(description = "Bearer {accessToken}", required = true)
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken
+            @AuthUser final AuthUserInfo authUserInfo
     ) {
-        // TODO: 유저 본인 정보 조회 기능 개발 후 삭제
-        return ResponseEntity.ok(new ReadUserResponse(
-                1L,
-                "김주민",
-                "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg"
-        ));
-    }
-
-    // TODO: 유저 본인 정보 조회 기능 개발 후 삭제
-    @Hidden
-    @GetMapping("/{id}")
-    public ResponseEntity<ReadUserResponse> readById(@PathVariable final Long id) {
-        final UserDto userDto = userService.readById(id);
+        final UserDto userDto = userService.readById(authUserInfo.userId());
         final ReadUserResponse response = ReadUserResponse.from(userDto);
 
         return ResponseEntity.ok(response);

--- a/src/main/resources/static/test-llm-proxy.html
+++ b/src/main/resources/static/test-llm-proxy.html
@@ -108,6 +108,12 @@
 <body>
 <h1>LLM 프록시 테스트</h1>
 
+<h2>Access Token 입력</h2>
+<div class="form-group">
+    <label for="accessToken">Access Token:</label>
+    <input id="accessToken" placeholder="Access Token을 입력하세요" type="text">
+</div>
+
 <div class="tab-container">
     <div class="tab active" id="ttsTab">텍스트-음성 변환</div>
     <div class="tab" id="sttTab">음성-텍스트 변환</div>
@@ -258,6 +264,10 @@
     });
 
     // 텍스트-음성 변환
+    function getAccessToken() {
+        return document.getElementById('accessToken').value;
+    }
+
     document.getElementById('ttsButton').addEventListener('click', async () => {
         const text = document.getElementById('ttsText').value;
         const statusElement = document.getElementById('ttsStatus');
@@ -274,6 +284,7 @@
             const response = await fetch('/api/v1/llm/text-to-speech', {
                 method: 'POST',
                 headers: {
+                    'Authorization': getAccessToken(),
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({text: text})
@@ -293,8 +304,8 @@
             statusElement.textContent = '오류 발생: ' + error.message;
         }
     });
-
     // URL에서 음성-텍스트 변환
+
     document.getElementById('sttUrlButton').addEventListener('click', async () => {
         const audioUrl = document.getElementById('sttUrl').value;
         const statusElement = document.getElementById('sttUrlStatus');
@@ -311,6 +322,7 @@
             const response = await fetch('/api/v1/llm/speech-to-text/url', {
                 method: 'POST',
                 headers: {
+                    'Authorization': getAccessToken(),
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({audioUrl: audioUrl})
@@ -329,8 +341,8 @@
             statusElement.textContent = '오류 발생: ' + error.message;
         }
     });
-
     // 파일에서 음성-텍스트 변환
+
     document.getElementById('sttFileButton').addEventListener('click', async () => {
         const fileInput = document.getElementById('sttFile');
         const statusElement = document.getElementById('sttFileStatus');
@@ -365,8 +377,8 @@
             statusElement.textContent = '오류 발생: ' + error.message;
         }
     });
-
     // 텍스트로 ChatGPT 응답 받기
+
     document.getElementById('chatgptTextButton').addEventListener('click', async () => {
         const text = document.getElementById('chatgptText').value;
         const statusElement = document.getElementById('chatgptTextStatus');
@@ -383,6 +395,7 @@
             const response = await fetch('/api/v1/llm/chatgpt/text', {
                 method: 'POST',
                 headers: {
+                    'Authorization': getAccessToken(),
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({text: text})
@@ -401,8 +414,8 @@
             statusElement.textContent = '오류 발생: ' + error.message;
         }
     });
-
     // STT 텍스트로 ChatGPT 응답 받기
+
     document.getElementById('chatgptSttButton').addEventListener('click', async () => {
         const audioText = document.getElementById('chatgptSttText').value;
         const statusElement = document.getElementById('chatgptSttStatus');
@@ -419,6 +432,7 @@
             const response = await fetch('/api/v1/llm/chatgpt/stt', {
                 method: 'POST',
                 headers: {
+                    'Authorization': getAccessToken(),
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({audioText: audioText})
@@ -455,6 +469,7 @@
             const response = await fetch('/api/v1/llm/chatgpt/audio-url', {
                 method: 'POST',
                 headers: {
+                    'Authorization': getAccessToken(),
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({audioUrl: audioUrl})


### PR DESCRIPTION
# 설명
인증 인가 기능을 추가했어요.

#18 브랜치 바탕으로 생성한 브랜치에서 작업한 거라 커밋이 겹쳤는데 [커밋 범위](https://github.com/saegil-project/Saegil-Server/pull/19/files/5b43c791b86301090811dc275553e9eb6b1ba56c..0bc70e4c6806dd6fff13d56d59be36fcc558b363)만 보면 됩니다.

기본적으로 모든 api 요청 시 access token을 포함해야 해요. 로그인이 필요 없는 api는 `WebConfiguration`의 `addInterceptors()` 메서드에서 `excludePathPatterns()` 체이닝 부분에 추가해주면 돼요. 
현재 llm 관련 요청은 exclude하지 않았기 때문에 인증된 사용자만 llm 요청이 가능합니다. 그래서 `test-llm-proxy.html`에 access token을 입력받고, 요청 헤더에 포함시키도록 코드를 추가했어요.

공지사항, 지도 관련 api를 로그인 한 사용자에게만 허용할지 그냥 열어둘지에 대해서는 다음 전체 회의에서 정해보죠.
