### PR TITLE
feat: 공지사항 크롤링 스케줄러를 선택적으로 활성화할 수 있도록 개선

### DIFF
--- a/src/main/java/com/newworld/saegil/notice/scheduler/NoticeScheduler.java
+++ b/src/main/java/com/newworld/saegil/notice/scheduler/NoticeScheduler.java
@@ -2,6 +2,7 @@ package com.newworld.saegil.notice.scheduler;
 
 import com.newworld.saegil.notice.service.NoticeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "spring.task.notice_scheduler.enabled", havingValue = "true")
 public class NoticeScheduler {
 
     private final NoticeService noticeService;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,6 +18,9 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  task:
+    notice_scheduler:
+      enabled: false
 server:
   port: 8080
 springdoc:


### PR DESCRIPTION
# 설명
- 공지사항 크롤러가 application.yml에서 enabled가 true일 때만 컴포넌트로 등록되도록 하였습니다.

### 배경
- 공지사항 크롤링 스케줄러가 로컬에서 서버 실행할 때나 테스트 시 동작하는 바람에 여러 모로 불편합니다.
- 공지사항 크롤링 스케줄러는 db에 있는 최신 공지사항 이후의 공지사항을 크롤링해옵니다.
- 그런데 테스트 시에는 h2 db를 사용하고, 데이터가 없는 상태로 시작해요.
- 그래서 테스트 돌릴 때마다 크롤링을 처음부터 진행해버려서 테스트 진행이 안돼요!
