### PR TITLE
feat: 로그아웃, 토큰 갱신, 토큰 유효성 검사 기능 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -86,7 +86,10 @@ public class AuthenticationController {
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
             @RequestBody @Valid final LogoutRequest request
     ) {
-        return null;
+        authenticationService.logout(accessToken, request.refreshToken());
+
+        return ResponseEntity.noContent()
+                             .build();
     }
 
     @GetMapping("/validate-token")

--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.authentication.controller;
 
+import com.newworld.saegil.authentication.domain.TokenType;
 import com.newworld.saegil.authentication.service.AuthenticationService;
 import com.newworld.saegil.authentication.service.LoginResult;
 import com.newworld.saegil.configuration.SwaggerConfiguration;
@@ -102,7 +103,10 @@ public class AuthenticationController {
     public ResponseEntity<ValidateTokenResponse> validateToken(
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken
     ) {
-        return null;
+        final boolean validated = authenticationService.isValidToken(TokenType.ACCESS, accessToken);
+        final ValidateTokenResponse response = new ValidateTokenResponse(validated);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/refresh-token")

--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -3,6 +3,7 @@ package com.newworld.saegil.authentication.controller;
 import com.newworld.saegil.authentication.domain.TokenType;
 import com.newworld.saegil.authentication.service.AuthenticationService;
 import com.newworld.saegil.authentication.service.LoginResult;
+import com.newworld.saegil.authentication.service.TokenRefreshResult;
 import com.newworld.saegil.configuration.SwaggerConfiguration;
 import com.newworld.saegil.global.swagger.ApiResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -118,7 +119,10 @@ public class AuthenticationController {
     public ResponseEntity<TokenRefreshResponse> refreshToken(
             @RequestBody @Valid final TokenRefreshRequest request
     ) {
-        return null;
+        final TokenRefreshResult result = authenticationService.refreshToken(LocalDateTime.now(), request.refreshToken());
+        final TokenRefreshResponse response = TokenRefreshResponse.from(result);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/withdrawal")

--- a/src/main/java/com/newworld/saegil/authentication/controller/TokenRefreshResponse.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/TokenRefreshResponse.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.authentication.controller;
 
+import com.newworld.saegil.authentication.service.TokenRefreshResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record TokenRefreshResponse(
@@ -10,4 +11,8 @@ public record TokenRefreshResponse(
         @Schema(description = "서비스 Refresh Token", example = "Bearer refresh-token-opqrstuvwxyz")
         String refreshToken
 ) {
+
+    public static TokenRefreshResponse from(final TokenRefreshResult result) {
+        return new TokenRefreshResponse(result.accessToken(), result.refreshToken());
+    }
 }

--- a/src/main/java/com/newworld/saegil/authentication/domain/BlacklistToken.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/BlacklistToken.java
@@ -1,0 +1,44 @@
+package com.newworld.saegil.authentication.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+@ToString(of = {"id", "userId", "tokenType", "token"})
+@Table(name = "blacklist_token")
+public class BlacklistToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TokenType tokenType;
+
+    @Column(nullable = false)
+    private String token;
+
+    public BlacklistToken(final Long userId, final TokenType tokenType, final String token) {
+        this.userId = userId;
+        this.tokenType = tokenType;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/newworld/saegil/authentication/repository/BlacklistTokenRepository.java
+++ b/src/main/java/com/newworld/saegil/authentication/repository/BlacklistTokenRepository.java
@@ -1,0 +1,9 @@
+package com.newworld.saegil.authentication.repository;
+
+import com.newworld.saegil.authentication.domain.BlacklistToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlacklistTokenRepository extends JpaRepository<BlacklistToken, Long> {
+}

--- a/src/main/java/com/newworld/saegil/authentication/repository/BlacklistTokenRepository.java
+++ b/src/main/java/com/newworld/saegil/authentication/repository/BlacklistTokenRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BlacklistTokenRepository extends JpaRepository<BlacklistToken, Long> {
+
+    boolean existsByUserIdAndToken(Long userId, String token);
 }

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -106,4 +106,16 @@ public class AuthenticationService {
         blacklistTokenRepository.save(blacklistAccessToken);
         blacklistTokenRepository.save(blacklistRefreshToken);
     }
+
+    public boolean isValidToken(final TokenType tokenType, final String targetToken) {
+        final PrivateClaims privateClaims = tokenProcessor.decode(tokenType, targetToken)
+                                                          .map(PrivateClaims::from)
+                                                          .orElse(null);
+        if (privateClaims == null) {
+            return false;
+        }
+
+        return userRepository.existsById(privateClaims.userId()) &&
+                !blacklistTokenRepository.existsByUserIdAndToken(privateClaims.userId(), targetToken);
+    }
 }

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -84,7 +84,7 @@ public class AuthenticationService {
             throw new NoSuchUserException("존재하지 않는 유저의 토큰입니다.");
         }
         if (blacklistTokenRepository.existsByUserIdAndToken(userId, token)) {
-            throw new InvalidTokenException("로그아웃되었습니다.");
+            throw new InvalidTokenException("사용할 수 없는 토큰입니다.");
         }
 
         return privateClaims;

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -118,4 +118,18 @@ public class AuthenticationService {
         return userRepository.existsById(privateClaims.userId()) &&
                 !blacklistTokenRepository.existsByUserIdAndToken(privateClaims.userId(), targetToken);
     }
+
+    public TokenRefreshResult refreshToken(final LocalDateTime requestTime, final String refreshToken) {
+        final PrivateClaims privateClaims = getValidPrivateClaims(TokenType.REFRESH, refreshToken);
+        final Token token = tokenProcessor.generateToken(requestTime, privateClaims.toMap());
+
+        final BlacklistToken blacklistRefreshToken = new BlacklistToken(
+                privateClaims.userId(),
+                TokenType.REFRESH,
+                refreshToken
+        );
+        blacklistTokenRepository.save(blacklistRefreshToken);
+
+        return new TokenRefreshResult(token.accessToken(), token.refreshToken());
+    }
 }

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -83,6 +83,9 @@ public class AuthenticationService {
         if (!userRepository.existsById(userId)) {
             throw new NoSuchUserException("존재하지 않는 유저의 토큰입니다.");
         }
+        if (blacklistTokenRepository.existsByUserIdAndToken(userId, token)) {
+            throw new InvalidTokenException("로그아웃되었습니다.");
+        }
 
         return privateClaims;
     }

--- a/src/main/java/com/newworld/saegil/authentication/service/TokenRefreshResult.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/TokenRefreshResult.java
@@ -1,0 +1,6 @@
+package com.newworld.saegil.authentication.service;
+
+public record TokenRefreshResult(
+        String accessToken,
+        String refreshToken) {
+}


### PR DESCRIPTION
# 설명
- 토큰 방식의 경우 토큰이 만료되기 전까지 토큰이 유효합니다.
- 로그아웃 한 사용자의 토큰의 경우 토큰 그 자체로는 만료가 되지 않았지만, 서비스에서 사용되면 안 됩니다.
- 그래서 BlacklistToken이라는 테이블로 무효화된 토큰을 관리하도록 했습니다.
- 토큰 갱신에 사용된 refresh token은 더이상 사용하지 못하도록 blacklist token에 등록하도록 했습니다.

주의: 스프링부트 실행 또는 테스트 실행 시 `NoticeScheduler`를 주석 처리한 후 실행시켜주세요. (#21 에서 관련 문제를 해결했습니다)