### PR TITLE
fix: llm 테스트 웹페이지 요청에 authorization 헤더 포함 및 swagger 요청에서 로그인 여부 검증 제외

### DIFF
--- a/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
@@ -22,6 +22,7 @@ public class WebConfiguration implements WebMvcConfigurer {
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/")
+                .excludePathPatterns("/webjars/swagger-ui/**")
                 .excludePathPatterns("/index.html")
                 .excludePathPatterns("/test-llm-proxy.html")
                 .excludePathPatterns("/api/v1/organizations/**")

--- a/src/main/resources/static/test-llm-proxy.html
+++ b/src/main/resources/static/test-llm-proxy.html
@@ -361,6 +361,9 @@
 
             const response = await fetch('/api/v1/llm/speech-to-text/upload', {
                 method: 'POST',
+                headers: {
+                    'Authorization': getAccessToken(),
+                },
                 body: formData
             });
 
@@ -508,6 +511,9 @@
 
             const response = await fetch('/api/v1/llm/chatgpt/upload', {
                 method: 'POST',
+                headers: {
+                    'Authorization': getAccessToken(),
+                },
                 body: formData
             });
 


### PR DESCRIPTION
- 문제1: 음성 파일 업로드할 때 Authorization 헤더 없이 요청을 보내는 바람에 401이 발생합니다.
- 문제2: swagger 접속 시 로그인 하라고 401이 발생합니다.
