### PR TITLE
feat: 공지사항 내용 크롤링 기능 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/notice/domain/crawler/HanaGeneralCrawler.java
+++ b/src/main/java/com/newworld/saegil/notice/domain/crawler/HanaGeneralCrawler.java
@@ -3,6 +3,7 @@ package com.newworld.saegil.notice.domain.crawler;
 import com.newworld.saegil.notice.domain.Notice;
 import com.newworld.saegil.notice.domain.NoticeCrawler;
 import com.newworld.saegil.notice.domain.NoticeType;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -12,14 +13,16 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class HanaGeneralCrawler implements NoticeCrawler {
+
+    private final NoticeCrawlerHelper noticeCrawlerHelper;
 
     @Override
     public Set<NoticeType> getSupportingNoticeType() {
@@ -83,14 +86,11 @@ public class HanaGeneralCrawler implements NoticeCrawler {
         final String onclick = titleElement.attr("onclick").trim();
         final String id = onclick.replaceAll(".*'detail',\\s*'(\\d+)',.*", "$1");
         final String webLink = noticeType.getDetailUrlPrefix() + id;
-
-        final Document document = Jsoup.connect(webLink).get();
-        final Element editorView = document.selectFirst("div.editor_view");
-        final String content = editorView != null ? editorView.text().substring(0, 100) : "";
+        final String content = noticeCrawlerHelper.extractContentBody(webLink, "div.editor_view");
 
         final Elements tds = element.select("td");
         final String dateValue = (tds.size() > 5) ? tds.get(5).text() : null;
-        final LocalDate date = parseDate(dateValue, webLink);
+        final LocalDate date = noticeCrawlerHelper.parseDate(dateValue, webLink);
 
         return new Notice(
                 title,
@@ -99,19 +99,5 @@ public class HanaGeneralCrawler implements NoticeCrawler {
                 date,
                 webLink
         );
-    }
-
-    private LocalDate parseDate(final String dateValue, final String webLink) {
-        if (dateValue == null) {
-            return null;
-        }
-
-        final String formatted = dateValue.replace(" ", "").substring(0, 10);
-        try {
-            return LocalDate.parse(formatted);
-        } catch (final DateTimeParseException e) {
-            log.warn("게시글 등록일 파싱에 실패했습니다. webLink = {}, dateValue = {}", webLink, dateValue);
-            return null;
-        }
     }
 }

--- a/src/main/java/com/newworld/saegil/notice/domain/crawler/HanaPressReleaseCrawler.java
+++ b/src/main/java/com/newworld/saegil/notice/domain/crawler/HanaPressReleaseCrawler.java
@@ -3,6 +3,7 @@ package com.newworld.saegil.notice.domain.crawler;
 import com.newworld.saegil.notice.domain.Notice;
 import com.newworld.saegil.notice.domain.NoticeCrawler;
 import com.newworld.saegil.notice.domain.NoticeType;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -11,14 +12,16 @@ import org.jsoup.select.Elements;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class HanaPressReleaseCrawler implements NoticeCrawler {
+
+    private final NoticeCrawlerHelper noticeCrawlerHelper;
 
     @Override
     public Set<NoticeType> getSupportingNoticeType() {
@@ -77,7 +80,7 @@ public class HanaPressReleaseCrawler implements NoticeCrawler {
         final String webLink = titleElement.attr("href");
         final Elements tds = element.select("td");
         final String dateValue = (tds.size() > 3) ? tds.get(3).text() : null;
-        final LocalDate date = parseDate(dateValue, webLink);
+        final LocalDate date = noticeCrawlerHelper.parseDate(dateValue, webLink);
 
         return new Notice(
                 title,
@@ -86,19 +89,5 @@ public class HanaPressReleaseCrawler implements NoticeCrawler {
                 date,
                 webLink
         );
-    }
-
-    private LocalDate parseDate(final String dateValue, final String webLink) {
-        if (dateValue == null) {
-            return null;
-        }
-
-        final String formatted = dateValue.replace(" ", "").substring(0, 10);
-        try {
-            return LocalDate.parse(formatted);
-        } catch (final DateTimeParseException e) {
-            log.warn("게시글 등록일 파싱에 실패했습니다. webLink = {}, dateValue = {}", webLink, dateValue);
-            return null;
-        }
     }
 }

--- a/src/main/java/com/newworld/saegil/notice/domain/crawler/HanaTenderNoticeCrawler.java
+++ b/src/main/java/com/newworld/saegil/notice/domain/crawler/HanaTenderNoticeCrawler.java
@@ -10,6 +10,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -67,7 +68,7 @@ public class HanaTenderNoticeCrawler implements NoticeCrawler {
         return newNotices;
     }
 
-    private Notice parseToNotice(final Element element, final NoticeType noticeType) {
+    private Notice parseToNotice(final Element element, final NoticeType noticeType) throws IOException {
         final Element titleElement = element.selectFirst("td.tit a");
         if (titleElement == null) {
             return null;
@@ -77,13 +78,17 @@ public class HanaTenderNoticeCrawler implements NoticeCrawler {
         final String id = onclick.replaceAll(".*fn_edit\\('(\\d+)'\\).*", "$1");
         final String webLink = noticeType.getDetailUrlPrefix() + id;
 
+        final Document document = Jsoup.connect(webLink).get();
+        final Element editorView = document.selectFirst("div.editor_view");
+        final String content = editorView != null ? editorView.text().substring(0, 100) : "";
+
         final Elements tds = element.select("td");
         final String dateValue = (tds.size() > 3) ? tds.get(3).text() : null;
         final LocalDate date = parseDate(dateValue, webLink);
 
         return new Notice(
                 title,
-                "",
+                content,
                 noticeType,
                 date,
                 webLink

--- a/src/main/java/com/newworld/saegil/notice/domain/crawler/NoticeCrawlerHelper.java
+++ b/src/main/java/com/newworld/saegil/notice/domain/crawler/NoticeCrawlerHelper.java
@@ -1,0 +1,37 @@
+package com.newworld.saegil.notice.domain.crawler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+@Slf4j
+@Component
+public class NoticeCrawlerHelper {
+
+    public String extractContentBody(final String webLink, final String elementSelector) throws IOException {
+        final Document document = Jsoup.connect(webLink).get();
+        final Element contentElement = document.selectFirst(elementSelector);
+
+        return contentElement != null ? contentElement.text().substring(0, 100) : "";
+    }
+
+    public LocalDate parseDate(final String dateValue, final String webLink) {
+        if (dateValue == null) {
+            return null;
+        }
+
+        final String formatted = dateValue.replace(" ", "").substring(0, 10);
+        try {
+            return LocalDate.parse(formatted);
+        } catch (final DateTimeParseException e) {
+            log.warn("게시글 등록일 파싱에 실패했습니다. webLink = {}, dateValue = {}", webLink, dateValue);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
# 설명
- 공지사항의 내용도 크롤링해서 저장합니다.
- 저번 회의에서 정한대로 언론 보도의 경우 빈 문자열을 저장하고, 나머지에 대해서는 100자만 저장하고 있습니다.