### PR TITLE
feat: 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -136,6 +136,9 @@ public class AuthenticationController {
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
             @RequestBody @Valid final WithdrawalRequest request
     ) {
-        return null;
+        authenticationService.withdrawal(accessToken, request.refreshToken());
+
+        return ResponseEntity.noContent()
+                             .build();
     }
 }

--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2Handler.java
@@ -6,4 +6,5 @@ public interface OAuth2Handler {
     String provideAuthCodeRequestUrl();
     String getOAuth2AccessToken(final String authorizationCode);
     OAuth2UserInfo getUserInfo(final String accessToken);
+    void unlink(String oauth2Id);
 }

--- a/src/main/java/com/newworld/saegil/authentication/service/InvalidWithdrawalException.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/InvalidWithdrawalException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.authentication.service;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidWithdrawalException extends CustomException {
+
+    public InvalidWithdrawalException(final String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Properties.java
+++ b/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Properties.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 @ConfigurationProperties(prefix = "oauth2.kakao")
 public record KakaoOAuth2Properties(
+        String adminKey,
         String clientId,
         String clientSecret,
         String redirectUri,

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -37,6 +37,7 @@ token:
     refresh-expired-hours: 336  # 14일
 oauth2:
   kakao:
+    admin-key: ${KAKAO_ADMIN_KEY}
     client_id: ${KAKAO_CLIENT_ID}
     client_secret: ${KAKAO_CLIENT_SECRET}
     redirect_uri: ${KAKAO_REDIRECT_URI}


### PR DESCRIPTION
# 설명
- 회원 탈퇴 기능을 추가했어요.
- [카카오 연결 끊기 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink)
- 액세스토큰 방식과 서비스앱 어드민키 방식이 있는데 서비스앱 어드민키 방식을 채택했어요. 이유는 다음과 같아요.
  - 현재 서비스 내에서 카카오에서 받은 액세스토큰을 관리하고 있지 않기 않음
  따라서, 액세스토큰 방식을 사용하려면 사용자에게 다시 카카오 로그인을 유도하거나 db에 카카오의 액세스토큰과 리프레시토큰을 저장해둔 후 사용해야 합니다.
  - oauthId는 민감한 정보도 아니고, 이미 user 필드에 저장되어 있기 때문에 그대로 사용하면 됨

- 카카오 로그인을 수행하면 카카오톡 `설정` > `카카오 계정` > `연결된 서비스 관리` > `외부 서비스` 에 저희 서비스 "새길"이 추가됩니다.
- 탈퇴를 진행하면 `설정` > `카카오 계정` > `연결된 서비스 관리` > `외부 서비스` 목록에서 제거됩니다.