### PR TITLE
refactor: 공지사항 최초 크롤링 시 날짜순으로 정렬 후 저장 및 크롤링 스케줄러 크론식 수정

### DIFF
--- a/src/main/java/com/newworld/saegil/notice/scheduler/NoticeScheduler.java
+++ b/src/main/java/com/newworld/saegil/notice/scheduler/NoticeScheduler.java
@@ -20,8 +20,8 @@ public class NoticeScheduler {
         noticeCrawlingService.fetchNewNotices();
     }
 
-    // 정각마다 실행
-    @Scheduled(cron = "0 0 * * * *")
+    // 매 시간 30분에 실행
+    @Scheduled(cron = "0 30 * * * *")
     public void periodicNoticeCheck() {
         noticeCrawlingService.fetchNewNotices();
     }

--- a/src/main/java/com/newworld/saegil/notice/service/NoticeCrawlingService.java
+++ b/src/main/java/com/newworld/saegil/notice/service/NoticeCrawlingService.java
@@ -30,6 +30,10 @@ public class NoticeCrawlingService {
 
         log.info("공지사항 크롤링 완료. 크롤링 소요 시간: {} ms", crawlEndTime - crawlStartTime);
 
+        if (noticeRepository.count() == 0) {
+            sortByDateAsc(newNoticesToSave);
+        }
+
         final long saveStartTime = System.currentTimeMillis();
         noticeRepository.saveAll(newNoticesToSave);
         final long saveEndTime = System.currentTimeMillis();
@@ -68,5 +72,22 @@ public class NoticeCrawlingService {
         );
 
         return newNotices;
+    }
+
+    private void sortByDateAsc(final List<Notice> newNoticesToSave) {
+        newNoticesToSave.sort(((o1, o2) -> {
+            if (o1.getDate() != null && o2.getDate() != null) {
+                return o1.getDate().compareTo(o2.getDate());
+            }
+            if (o1.getDate() == null && o2.getDate() == null) {
+                return 0;
+            }
+            if (o1.getDate() != null && o2.getDate() == null) {
+                return 1;
+            }
+            else {
+                return -1;
+            }
+        }));
     }
 }


### PR DESCRIPTION
# 설명
- #30 에서 언급한 수정사항입니다.
  - 공지사항 최초 크롤링 시 날짜순으로 정렬한 수 저장합니다.
  - 최초 크롤링인 여부는 notice 테이블의 row 수를 기반으로 판단합니다.
  - 매 시간 정각에 크롤링 스케줄러를 실행시켰는데, 매 시간 30분마다 실행하도록 수정했습니다.