### PR TITLE
feat: access token을 사용한 oauth 로그인 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -57,18 +57,18 @@ public class AuthenticationController {
                 .build();
     }
 
-    @PostMapping("/login/{oauth2Type}")
+    @PostMapping("/login/{oauth2Type}/authorization-code")
     @Operation(
-            summary = "OAuth 2.0 로그인",
+            summary = "OAuth 2.0 로그인 (Authorization Code 사용)",
             description = "OAuth 2.0 Authorization code를 통해 로그인합니다."
     )
     @ApiResponse(responseCode = ApiResponseCode.OK, description = "로그인 성공")
-    public ResponseEntity<LoginInformationResponse> login(
+    public ResponseEntity<LoginInformationResponse> loginWithAuthorizationCode(
             @Parameter(description = "OAuth 2.0 Type (대소문자 상관 없음)", example = "KAKAO")
             @PathVariable final String oauth2Type,
-            @RequestBody @Valid final LoginRequest request
+            @RequestBody @Valid final LoginWithAuthorizationCodeRequest request
     ) {
-        final LoginResult loginResult = authenticationService.login(
+        final LoginResult loginResult = authenticationService.loginWithAuthorizationCode(
                 oauth2Type,
                 request.authorizationCode(),
                 LocalDateTime.now()

--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -78,6 +78,27 @@ public class AuthenticationController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/login/{oauth2Type}")
+    @Operation(
+            summary = "OAuth 2.0 로그인 (Access Token 사용)",
+            description = "OAuth 2.0 Access Token을 통해 로그인합니다."
+    )
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "로그인 성공")
+    public ResponseEntity<LoginInformationResponse> login(
+            @Parameter(description = "OAuth 2.0 Type (대소문자 상관 없음)", example = "KAKAO")
+            @PathVariable final String oauth2Type,
+            @RequestBody @Valid final LoginWithAccessTokenRequest request
+    ) {
+        final LoginResult loginResult = authenticationService.loginWithAccessToken(
+                oauth2Type,
+                request.accessToken(),
+                LocalDateTime.now()
+        );
+        final LoginInformationResponse response = LoginInformationResponse.from(loginResult);
+
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/logout")
     @Operation(
             summary = "로그아웃",

--- a/src/main/java/com/newworld/saegil/authentication/controller/LoginWithAccessTokenRequest.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/LoginWithAccessTokenRequest.java
@@ -1,0 +1,12 @@
+package com.newworld.saegil.authentication.controller;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+public record LoginWithAccessTokenRequest(
+
+        @NotEmpty(message = "Access Token을 입력해주세요.")
+        @Schema(description = "OAuth 2.0 Access Token", example = "asdfasdfasdfasdf")
+        String accessToken
+) {
+}

--- a/src/main/java/com/newworld/saegil/authentication/controller/LoginWithAuthorizationCodeRequest.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/LoginWithAuthorizationCodeRequest.java
@@ -3,7 +3,7 @@ package com.newworld.saegil.authentication.controller;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 
-public record LoginRequest(
+public record LoginWithAuthorizationCodeRequest(
 
         @NotEmpty(message = "Authorization code을 입력해주세요.")
         @Schema(description = "OAuth 2.0 Authorization code", example = "asdfasdfasdfasdf")

--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2HandlerComposite.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2HandlerComposite.java
@@ -19,6 +19,12 @@ public class OAuth2HandlerComposite {
         }
     }
 
+    public OAuth2Handler findHandler(final String oauth2TypeName) {
+        final OAuth2Type oauth2Type = OAuth2Type.from(oauth2TypeName);
+
+        return findHandler(oauth2Type);
+    }
+
     public OAuth2Handler findHandler(final OAuth2Type oauth2Type) {
         final OAuth2Handler handler = handlerMappings.get(oauth2Type);
         if (handler == null) {

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -40,19 +40,14 @@ public class AuthenticationService {
             final String authorizationCode,
             final LocalDateTime requestTime
     ) {
-        final OAuth2UserInfo oauth2UserInfo = fetchOAuth2UserInfo(oauth2TypeName, authorizationCode);
+        final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2TypeName);
+        final String oauth2AccessToken = oauth2Handler.getOAuth2AccessToken(authorizationCode);
+        final OAuth2UserInfo oauth2UserInfo = oauth2Handler.getUserInfo(oauth2AccessToken);
         final User user = findOrPersistUser(oauth2UserInfo);
         final PrivateClaims privateClaims = new PrivateClaims(user.getId());
         final Token token = tokenProcessor.generateToken(requestTime, privateClaims.toMap());
 
         return new LoginResult(user.getId(), token.accessToken(), token.refreshToken());
-    }
-
-    private OAuth2UserInfo fetchOAuth2UserInfo(final String oauth2TypeName, final String authorizationCode) {
-        final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2TypeName);
-        final String oauth2AccessToken = oauth2Handler.getOAuth2AccessToken(authorizationCode);
-
-        return oauth2Handler.getUserInfo(oauth2AccessToken);
     }
 
     private User findOrPersistUser(final OAuth2UserInfo oauth2UserInfo) {

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -37,7 +37,7 @@ public class AuthenticationService {
         return oauth2Handler.provideAuthCodeRequestUrl();
     }
 
-    public LoginResult login(
+    public LoginResult loginWithAuthorizationCode(
             final String oauth2TypeName,
             final String authorizationCode,
             final LocalDateTime requestTime

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -71,6 +71,20 @@ public class AuthenticationService {
         });
     }
 
+    public LoginResult loginWithAccessToken(
+            final String oauth2TypeName,
+            final String oauth2AccessToken,
+            final LocalDateTime requestTime
+    ) {
+        final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2TypeName);
+        final OAuth2UserInfo oauth2UserInfo = oauth2Handler.getUserInfo(oauth2AccessToken);
+        final User user = findOrPersistUser(oauth2UserInfo);
+        final PrivateClaims privateClaims = new PrivateClaims(user.getId());
+        final Token token = tokenProcessor.generateToken(requestTime, privateClaims.toMap());
+
+        return new LoginResult(user.getId(), token.accessToken(), token.refreshToken());
+    }
+
     public PrivateClaims getValidPrivateClaims(final TokenType tokenType, final String token) {
         final Claims claims = tokenProcessor.decode(tokenType, token)
                                             .orElseThrow(() -> new InvalidTokenException("유효한 토큰이 아닙니다."));

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -4,7 +4,6 @@ import com.newworld.saegil.authentication.domain.BlacklistToken;
 import com.newworld.saegil.authentication.domain.InvalidTokenException;
 import com.newworld.saegil.authentication.domain.OAuth2Handler;
 import com.newworld.saegil.authentication.domain.OAuth2HandlerComposite;
-import com.newworld.saegil.authentication.domain.OAuth2Type;
 import com.newworld.saegil.authentication.domain.OAuth2UserInfo;
 import com.newworld.saegil.authentication.domain.PrivateClaims;
 import com.newworld.saegil.authentication.domain.Token;
@@ -31,8 +30,7 @@ public class AuthenticationService {
     private final BlacklistTokenRepository blacklistTokenRepository;
 
     public String getAuthCodeRequestUrl(final String oauth2TypeName) {
-        final OAuth2Type oauth2Type = OAuth2Type.from(oauth2TypeName);
-        final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2Type);
+        final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2TypeName);
 
         return oauth2Handler.provideAuthCodeRequestUrl();
     }
@@ -51,8 +49,7 @@ public class AuthenticationService {
     }
 
     private OAuth2UserInfo fetchOAuth2UserInfo(final String oauth2TypeName, final String authorizationCode) {
-        final OAuth2Type oauth2Type = OAuth2Type.from(oauth2TypeName);
-        final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2Type);
+        final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2TypeName);
         final String oauth2AccessToken = oauth2Handler.getOAuth2AccessToken(authorizationCode);
 
         return oauth2Handler.getUserInfo(oauth2AccessToken);

--- a/src/test/java/com/newworld/saegil/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/newworld/saegil/authentication/service/AuthenticationServiceTest.java
@@ -100,7 +100,7 @@ class AuthenticationServiceTest {
                 given(mockOAuth2Handler.getUserInfo(카카오_액세스_토큰)).willReturn(OAUTH2_회원_정보);
 
                 // when
-                final LoginResult result = authenticationService.login("KAKAO", 카카오_인증_코드, LocalDateTime.now());
+                final LoginResult result = authenticationService.loginWithAuthorizationCode("KAKAO", 카카오_인증_코드, LocalDateTime.now());
 
                 // then
                 SoftAssertions.assertSoftly(softAssertions -> {
@@ -123,7 +123,7 @@ class AuthenticationServiceTest {
                 final long userCountBeforeSignup = userRepository.count();
 
                 // when
-                final LoginResult result = authenticationService.login("KAKAO", 카카오_인증_코드, LocalDateTime.now());
+                final LoginResult result = authenticationService.loginWithAuthorizationCode("KAKAO", 카카오_인증_코드, LocalDateTime.now());
                 entityManager.flush();
                 entityManager.clear();
 

--- a/src/test/java/com/newworld/saegil/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/newworld/saegil/authentication/service/AuthenticationServiceTest.java
@@ -61,7 +61,8 @@ class AuthenticationServiceTest {
 
     @BeforeEach
     void setUp() {
-        given(oauth2HandlerComposite.findHandler(any())).willReturn(mockOAuth2Handler);
+        given(oauth2HandlerComposite.findHandler(any(String.class))).willReturn(mockOAuth2Handler);
+        given(oauth2HandlerComposite.findHandler(any(OAuth2Type.class))).willReturn(mockOAuth2Handler);
     }
 
     @Nested


### PR DESCRIPTION
# 설명
- 안드로이드는 자체적으로 access token을 받아올 수 있기 때문에 access token을 사용한 로그인을 추가하였습니다.
- 기존의 api 엔드포인트를 그대로 사용하였고, 이전의 authorization code를 사용한 api는 `api/v1/oauth2/login{oauth2Type}/authorization-code`로 변경하였습니다.