### PR TITLE
docs: Authorization 헤더 값에 대한 설명 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -107,6 +107,7 @@ public class AuthenticationController {
     )
     @ApiResponse(responseCode = ApiResponseCode.NO_CONTENT, description = "로그아웃 성공")
     public ResponseEntity<Void> logout(
+            @Parameter(description = "서비스 Access Token", example = "Bearer access-token-abcdefghijklmn")
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
             @RequestBody @Valid final LogoutRequest request
     ) {
@@ -124,6 +125,7 @@ public class AuthenticationController {
     )
     @ApiResponse(responseCode = ApiResponseCode.OK, description = "Access Token 유효성 검사 성공")
     public ResponseEntity<ValidateTokenResponse> validateToken(
+            @Parameter(description = "서비스 Access Token", example = "Bearer access-token-abcdefghijklmn")
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken
     ) {
         final boolean validated = authenticationService.isValidToken(TokenType.ACCESS, accessToken);
@@ -158,6 +160,7 @@ public class AuthenticationController {
     )
     @ApiResponse(responseCode = ApiResponseCode.NO_CONTENT, description = "회원 탈퇴 성공")
     public ResponseEntity<Void> withdrawal(
+            @Parameter(description = "서비스 Access Token", example = "Bearer access-token-abcdefghijklmn")
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
             @RequestBody @Valid final WithdrawalRequest request
     ) {

--- a/src/main/java/com/newworld/saegil/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/SwaggerConfiguration.java
@@ -39,7 +39,7 @@ public class SwaggerConfiguration {
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
                 .bearerFormat("JWT")
-                .description("서비스에서 발급한 Bearer Token");
+                .description("서비스에서 발급한 Bearer Access Token");
     }
 
     private SecurityScheme oauthSecurityScheme() {


### PR DESCRIPTION
# 설명
- 로그아웃, 탈퇴 등에서 Authorization Header에 Access Token을 받는데, 기존에는 swagger 문서에 "Authorization" 이라고만 나와있어서 어떤 값이 필요한지 모호한 문제가 있었습니다. 그래서 서비스 Access Token을 넣으면 된다는 description을 추가했어요.