### PR TITLE
feat: Authorization 헤더 관련 swagger customizer 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/newworld/saegil/authentication/controller/AuthenticationController.java
@@ -107,7 +107,6 @@ public class AuthenticationController {
     )
     @ApiResponse(responseCode = ApiResponseCode.NO_CONTENT, description = "로그아웃 성공")
     public ResponseEntity<Void> logout(
-            @Parameter(description = "서비스 Access Token", example = "Bearer access-token-abcdefghijklmn")
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
             @RequestBody @Valid final LogoutRequest request
     ) {
@@ -125,7 +124,6 @@ public class AuthenticationController {
     )
     @ApiResponse(responseCode = ApiResponseCode.OK, description = "Access Token 유효성 검사 성공")
     public ResponseEntity<ValidateTokenResponse> validateToken(
-            @Parameter(description = "서비스 Access Token", example = "Bearer access-token-abcdefghijklmn")
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken
     ) {
         final boolean validated = authenticationService.isValidToken(TokenType.ACCESS, accessToken);
@@ -160,7 +158,6 @@ public class AuthenticationController {
     )
     @ApiResponse(responseCode = ApiResponseCode.NO_CONTENT, description = "회원 탈퇴 성공")
     public ResponseEntity<Void> withdrawal(
-            @Parameter(description = "서비스 Access Token", example = "Bearer access-token-abcdefghijklmn")
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String accessToken,
             @RequestBody @Valid final WithdrawalRequest request
     ) {

--- a/src/main/java/com/newworld/saegil/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/SwaggerConfiguration.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.OAuthFlows;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
@@ -23,9 +22,7 @@ public class SwaggerConfiguration {
         return new OpenAPI()
                 .info(apiInfo)
                 .components(components())
-                .addServersItem(new Server().url("/"))
-                .addSecurityItem(new SecurityRequirement().addList(SERVICE_SECURITY_SCHEME_NAME))
-                .addSecurityItem(new SecurityRequirement().addList(OAUTH_SECURITY_SCHEME_NAME));
+                .addServersItem(new Server().url("/"));
     }
 
     private Components components() {

--- a/src/main/java/com/newworld/saegil/global/swagger/AuthorizationHeaderSwaggerCustomizer.java
+++ b/src/main/java/com/newworld/saegil/global/swagger/AuthorizationHeaderSwaggerCustomizer.java
@@ -1,0 +1,77 @@
+package com.newworld.saegil.global.swagger;
+
+import com.newworld.saegil.authentication.annotation.AuthUser;
+import com.newworld.saegil.configuration.SwaggerConfiguration;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@Component
+public class AuthorizationHeaderSwaggerCustomizer implements OperationCustomizer {
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        ignoreSwaggerParameterAboutAuthorizationHeader(operation);
+
+        boolean isNeedAuthorizationHeader =
+                Arrays.stream(handlerMethod.getMethodParameters())
+                      .anyMatch(param ->
+                              hasAuthUserAnnotation(param) || hasRequestHeaderWithFieldNameAccessToken(param)
+                      );
+
+        if (isNeedAuthorizationHeader) {
+            operation.addParametersItem(customAuthHeaderParameter());
+            operation.addSecurityItem(
+                    new SecurityRequirement().addList(SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)
+            );
+        }
+
+        return operation;
+    }
+
+    private void ignoreSwaggerParameterAboutAuthorizationHeader(final Operation operation) {
+        if (operation.getParameters() == null) {
+            return;
+        }
+
+        operation.setParameters(
+                operation.getParameters().stream()
+                         .filter(this::hasNothingToDoWithAuthorizationHeader)
+                         .collect(Collectors.toList()));
+
+    }
+
+    private boolean hasNothingToDoWithAuthorizationHeader(final Parameter p) {
+        return (!"AuthUserInfo".equalsIgnoreCase(p.getName()))
+                && (!"Authorization".equalsIgnoreCase(p.getName()));
+    }
+
+    private boolean hasAuthUserAnnotation(final MethodParameter param) {
+        return param.getParameterAnnotation(AuthUser.class) != null;
+    }
+
+    private boolean hasRequestHeaderWithFieldNameAccessToken(final MethodParameter param) {
+        return param.getParameterAnnotation(RequestHeader.class) != null
+                && "Authorization".equalsIgnoreCase(param.getParameterAnnotation(RequestHeader.class).name())
+                && "accessToken".equalsIgnoreCase(param.getParameter().getName());
+    }
+
+    private Parameter customAuthHeaderParameter() {
+        return new Parameter()
+                .in("header")
+                .schema(new StringSchema())
+                .name("Authorization")
+                .description("서비스 Access Token")
+                .required(true)
+                .example("Bearer access-token-abcdefghijklmn");
+    }
+}

--- a/src/main/java/com/newworld/saegil/llm/controller/SpeechToTextController.java
+++ b/src/main/java/com/newworld/saegil/llm/controller/SpeechToTextController.java
@@ -1,6 +1,9 @@
 package com.newworld.saegil.llm.controller;
 
+import com.newworld.saegil.configuration.SwaggerConfiguration;
 import com.newworld.saegil.llm.service.SpeechToTextService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +25,11 @@ public class SpeechToTextController {
 
     private final SpeechToTextService speechToTextService;
 
+    @Operation(
+            summary = "음성 url 속 음성을 텍스트로 변환",
+            description = "음성 url 속 음성을 텍스트로 변환해서 반환합니다.",
+            security = @SecurityRequirement(name = SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)
+    )
     @PostMapping("/audio-url")
     public ResponseEntity<SpeechToTextResponse> speechToTextFromUrl(@RequestBody final SpeechToTextUrlRequest request) {
         log.info("Received speech-to-text URL request: {}", request.audioUrl());
@@ -31,6 +39,11 @@ public class SpeechToTextController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "음성 파일의 음성을 텍스트로 변환",
+            description = "음성 파일의 음성을 텍스트로 변환해서 반환합니다.",
+            security = @SecurityRequirement(name = SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)
+    )
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SpeechToTextResponse> speechToTextFromFile(@RequestPart("file") final MultipartFile multipartFile) {
         log.info("Received speech-to-text file upload request: {}", multipartFile.getOriginalFilename());

--- a/src/main/java/com/newworld/saegil/user/controller/UserController.java
+++ b/src/main/java/com/newworld/saegil/user/controller/UserController.java
@@ -7,7 +7,6 @@ import com.newworld.saegil.global.swagger.ApiResponseCode;
 import com.newworld.saegil.user.service.UserDto;
 import com.newworld.saegil.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,7 +32,6 @@ public class UserController {
     )
     @ApiResponse(responseCode = ApiResponseCode.OK, description = "유저 본인 정보 조회 성공")
     public ResponseEntity<ReadUserResponse> readUserInfo(
-            @Parameter(description = "Bearer {accessToken}", required = true)
             @AuthUser final AuthUserInfo authUserInfo
     ) {
         final UserDto userDto = userService.readById(authUserInfo.userId());


### PR DESCRIPTION
# 설명
아래의 경우에 대해 Authorization 헤더에 access token을 입력하라는 설명과 `@SecurityRequirement` 설정을 추가하는 customizer 입니다.
- `@RequestHeader`를 통해 직접적으로 사용하는 경우
- ArgumentResolver에서 사용하는 경우
- `@SecurityRequirement(name = SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)` 를 사용하는 경우

(추가적으로 `SpeechToTextController`에 `@SecurityRequirement` 설정이 누락되어 있어서 추가했어요)

[적용 전]
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/288b1e8d-203d-4e7d-a412-c2324772874c" />

[적용 후]
<img width="1149" alt="image" src="https://github.com/user-attachments/assets/a573a7be-7d7e-4715-8820-236729798db5" />
