### PR TITLE
feat: 유저 생성 시 프로필 이미지에 카카오 프로필 이미지 대신 기본 이미지 사용

### DIFF
--- a/src/main/java/com/newworld/saegil/authentication/domain/OAuth2UserInfo.java
+++ b/src/main/java/com/newworld/saegil/authentication/domain/OAuth2UserInfo.java
@@ -3,7 +3,6 @@ package com.newworld.saegil.authentication.domain;
 public record OAuth2UserInfo(
         String oauth2Id,
         OAuth2Type oauth2Type,
-        String nickname,
-        String profileImageUrl
+        String nickname
 ) {
 }

--- a/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/newworld/saegil/authentication/service/AuthenticationService.java
@@ -14,6 +14,7 @@ import com.newworld.saegil.user.domain.User;
 import com.newworld.saegil.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,9 @@ public class AuthenticationService {
     private final TokenProcessor tokenProcessor;
     private final UserRepository userRepository;
     private final BlacklistTokenRepository blacklistTokenRepository;
+
+    @Value("${user.default.profile-image-url}")
+    private String defaultProfileImageUrl;
 
     public String getAuthCodeRequestUrl(final String oauth2TypeName) {
         final OAuth2Handler oauth2Handler = oauth2HandlerComposite.findHandler(oauth2TypeName);
@@ -57,7 +61,7 @@ public class AuthenticationService {
         ).orElseGet(() -> {
             final User newUser = new User(
                     oauth2UserInfo.nickname(),
-                    oauth2UserInfo.profileImageUrl(),
+                    defaultProfileImageUrl,
                     oauth2UserInfo.oauth2Id(),
                     oauth2UserInfo.oauth2Type()
             );

--- a/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Handler.java
+++ b/src/main/java/com/newworld/saegil/security/oauth2/KakaoOAuth2Handler.java
@@ -105,9 +105,8 @@ public class KakaoOAuth2Handler implements OAuth2Handler {
 
         final Map<String, Object> properties = (Map<String, Object>) body.get("properties");
         final String nickname = (String) properties.get("nickname");
-        final String profileImageUrl = (String) properties.get("profile_image");
 
-        return new OAuth2UserInfo(id, OAuth2Type.KAKAO, nickname, profileImageUrl);
+        return new OAuth2UserInfo(id, OAuth2Type.KAKAO, nickname);
     }
 
     @Override

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -42,6 +42,9 @@ oauth2:
     client_secret: ${KAKAO_CLIENT_SECRET}
     redirect_uri: ${KAKAO_REDIRECT_URI}
     scope: ${KAKAO_SCOPE}
+user:
+  default:
+    profile-image-url: ${DEFAULT_PROFILE_IMAGE_URL}
 llm:
   proxy:
     llm-server-url: ${PROXY_LLM_SERVICE_URL:http://localhost:9090}

--- a/src/test/java/com/newworld/saegil/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/newworld/saegil/authentication/service/AuthenticationServiceTest.java
@@ -75,8 +75,7 @@ class AuthenticationServiceTest {
         private static final OAuth2UserInfo OAUTH2_회원_정보 = new OAuth2UserInfo(
                 "1234567",
                 OAuth2Type.KAKAO,
-                "홍길동",
-                "http://example.com/profile.jpg"
+                "홍길동"
         );
 
         @Nested
@@ -89,7 +88,7 @@ class AuthenticationServiceTest {
                 final User 가입된_유저 = userRepository.save(
                         new User(
                                 OAUTH2_회원_정보.nickname(),
-                                OAUTH2_회원_정보.profileImageUrl(),
+                                "http://example.com/profile.jpg",
                                 OAUTH2_회원_정보.oauth2Id(),
                                 OAUTH2_회원_정보.oauth2Type()
                         )


### PR DESCRIPTION
# 설명
저번 회의에서 사용자 회원가입 시 프로필이미지를 카카오 프로필 이미지 말고 서비스 캐릭터를 사용하기로 했습니다.
기본이미지url은 yml에서 설정할 수 있도록 했습니다.
여기도 시뮬레이션 아이콘의 경우와 마찬가지로 이미지 관련 api나 버킷이 없기 때문에 이 pr에 이미지 첨부하고 해당 url을 기본이미지url로 설정해두려고 합니다.

![image](https://github.com/user-attachments/assets/b19e375b-7ffc-4043-aa14-4ceb76bbcce9)
