### PR TITLE
feat: 주소 혹은 장소명에 해당하는 위경도 좌표값을 구하는 기능 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/configuration/PropertiesConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/PropertiesConfiguration.java
@@ -3,6 +3,7 @@ package com.newworld.saegil.configuration;
 import com.newworld.saegil.llm.config.FileProperties;
 import com.newworld.saegil.llm.config.ProxyProperties;
 import com.newworld.saegil.location.naver.NaverGeocodingProperties;
+import com.newworld.saegil.location.naver.NaverLocationSearchProperties;
 import com.newworld.saegil.security.jwt.JwtProperties;
 import com.newworld.saegil.security.oauth2.KakaoOAuth2Properties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -15,7 +16,8 @@ import org.springframework.context.annotation.Configuration;
         ProxyProperties.class,
         FileProperties.class,
         CorsProperties.class,
-        NaverGeocodingProperties.class
+        NaverGeocodingProperties.class,
+        NaverLocationSearchProperties.class
 })
 public class PropertiesConfiguration {
 }

--- a/src/main/java/com/newworld/saegil/configuration/PropertiesConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/PropertiesConfiguration.java
@@ -2,6 +2,7 @@ package com.newworld.saegil.configuration;
 
 import com.newworld.saegil.llm.config.FileProperties;
 import com.newworld.saegil.llm.config.ProxyProperties;
+import com.newworld.saegil.location.naver.NaverGeocodingProperties;
 import com.newworld.saegil.security.jwt.JwtProperties;
 import com.newworld.saegil.security.oauth2.KakaoOAuth2Properties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -13,7 +14,8 @@ import org.springframework.context.annotation.Configuration;
         KakaoOAuth2Properties.class,
         ProxyProperties.class,
         FileProperties.class,
-        CorsProperties.class
+        CorsProperties.class,
+        NaverGeocodingProperties.class
 })
 public class PropertiesConfiguration {
 }

--- a/src/main/java/com/newworld/saegil/location/Address.java
+++ b/src/main/java/com/newworld/saegil/location/Address.java
@@ -1,0 +1,17 @@
+package com.newworld.saegil.location;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode
+@ToString
+public class Address {
+
+    private final String roadAddress;
+    private final String jibunAddress;
+    private final Coordinates coordinates;
+}

--- a/src/main/java/com/newworld/saegil/location/AddressResolveFailedException.java
+++ b/src/main/java/com/newworld/saegil/location/AddressResolveFailedException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.location;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class AddressResolveFailedException extends CustomException {
+
+    public AddressResolveFailedException(final String message) {
+        super(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/newworld/saegil/location/AddressResolver.java
+++ b/src/main/java/com/newworld/saegil/location/AddressResolver.java
@@ -8,12 +8,12 @@ import org.springframework.util.StringUtils;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class CoordinatesResolver {
+public class AddressResolver {
 
     private final GeocodingHandler geocodingHandler;
     private final LocalSearchHandler localSearchHandler;
 
-    public Coordinates resolve(String address, String placeName) {
+    public Address resolve(String address, String placeName) {
         if (StringUtils.hasText(address)) {
             return resolveByAddressOrElsePlaceName(address, placeName);
         }
@@ -26,9 +26,9 @@ public class CoordinatesResolver {
         throw new AddressResolveFailedException("주소와 장소명 모두 없음");
     }
 
-    private Coordinates resolveByAddressOrElsePlaceName(final String address, final String placeName) {
+    private Address resolveByAddressOrElsePlaceName(final String address, final String placeName) {
         try {
-            return geocodingHandler.getCoordinates(address);
+            return geocodingHandler.getAddress(address);
         } catch (GeocodingException e) {
             log.error("주소({})의 좌표를 찾을 수 없습니다: {}", address, e.getMessage());
 
@@ -40,9 +40,9 @@ public class CoordinatesResolver {
         }
     }
 
-    private Coordinates resolveByPlaceName(final String placeName) {
+    private Address resolveByPlaceName(final String placeName) {
         try {
-            return localSearchHandler.getCoordinates(placeName);
+            return localSearchHandler.getAddress(placeName);
         } catch (LocationSearchException e) {
             log.error("장소({})의 좌표를 찾을 수 없습니다: {}", placeName, e.getMessage());
 

--- a/src/main/java/com/newworld/saegil/location/Coordinates.java
+++ b/src/main/java/com/newworld/saegil/location/Coordinates.java
@@ -1,0 +1,15 @@
+package com.newworld.saegil.location;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode
+@ToString
+public class Coordinates {
+    private final double latitude;
+    private final double longitude;
+}

--- a/src/main/java/com/newworld/saegil/location/CoordinatesResolver.java
+++ b/src/main/java/com/newworld/saegil/location/CoordinatesResolver.java
@@ -1,0 +1,52 @@
+package com.newworld.saegil.location;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CoordinatesResolver {
+
+    private final GeocodingHandler geocodingHandler;
+    private final LocalSearchHandler localSearchHandler;
+
+    public Coordinates resolve(String address, String placeName) {
+        if (StringUtils.hasText(address)) {
+            return resolveByAddressOrElsePlaceName(address, placeName);
+        }
+
+        if (StringUtils.hasText(placeName)) {
+            return resolveByPlaceName(placeName);
+        }
+
+        log.error("주소와 장소명 모두 없음");
+        throw new AddressResolveFailedException("주소와 장소명 모두 없음");
+    }
+
+    private Coordinates resolveByAddressOrElsePlaceName(final String address, final String placeName) {
+        try {
+            return geocodingHandler.getCoordinates(address);
+        } catch (GeocodingException e) {
+            log.error("주소({})의 좌표를 찾을 수 없습니다: {}", address, e.getMessage());
+
+            if (StringUtils.hasText(placeName)) {
+                return resolveByPlaceName(placeName);
+            }
+
+            throw new AddressResolveFailedException("주소(" + address + ")의 좌표를 찾을 수 없습니다: " + e.getMessage());
+        }
+    }
+
+    private Coordinates resolveByPlaceName(final String placeName) {
+        try {
+            return localSearchHandler.getCoordinates(placeName);
+        } catch (LocationSearchException e) {
+            log.error("장소({})의 좌표를 찾을 수 없습니다: {}", placeName, e.getMessage());
+
+            throw new AddressResolveFailedException("장소(" + placeName + ")의 좌표를 찾을 수 없습니다: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/newworld/saegil/location/GeocodingException.java
+++ b/src/main/java/com/newworld/saegil/location/GeocodingException.java
@@ -1,0 +1,8 @@
+package com.newworld.saegil.location;
+
+public class GeocodingException extends Exception {
+
+    public GeocodingException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/newworld/saegil/location/GeocodingHandler.java
+++ b/src/main/java/com/newworld/saegil/location/GeocodingHandler.java
@@ -1,0 +1,6 @@
+package com.newworld.saegil.location;
+
+public interface GeocodingHandler {
+
+    Coordinates getCoordinates(String address) throws GeocodingException;
+}

--- a/src/main/java/com/newworld/saegil/location/GeocodingHandler.java
+++ b/src/main/java/com/newworld/saegil/location/GeocodingHandler.java
@@ -2,5 +2,5 @@ package com.newworld.saegil.location;
 
 public interface GeocodingHandler {
 
-    Coordinates getCoordinates(String address) throws GeocodingException;
+    Address getAddress(String address) throws GeocodingException;
 }

--- a/src/main/java/com/newworld/saegil/location/LocalSearchHandler.java
+++ b/src/main/java/com/newworld/saegil/location/LocalSearchHandler.java
@@ -2,5 +2,5 @@ package com.newworld.saegil.location;
 
 public interface LocalSearchHandler {
 
-    Coordinates getCoordinates(String placeName) throws LocationSearchException;
+    Address getAddress(String placeName) throws LocationSearchException;
 }

--- a/src/main/java/com/newworld/saegil/location/LocalSearchHandler.java
+++ b/src/main/java/com/newworld/saegil/location/LocalSearchHandler.java
@@ -1,0 +1,6 @@
+package com.newworld.saegil.location;
+
+public interface LocalSearchHandler {
+
+    Coordinates getCoordinates(String placeName) throws LocationSearchException;
+}

--- a/src/main/java/com/newworld/saegil/location/LocationSearchException.java
+++ b/src/main/java/com/newworld/saegil/location/LocationSearchException.java
@@ -1,0 +1,8 @@
+package com.newworld.saegil.location;
+
+public class LocationSearchException extends Exception {
+
+    public LocationSearchException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/newworld/saegil/location/naver/NaverGeocodingHandler.java
+++ b/src/main/java/com/newworld/saegil/location/naver/NaverGeocodingHandler.java
@@ -1,0 +1,92 @@
+package com.newworld.saegil.location.naver;
+
+import com.newworld.saegil.location.Coordinates;
+import com.newworld.saegil.location.GeocodingException;
+import com.newworld.saegil.location.GeocodingHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NaverGeocodingHandler implements GeocodingHandler {
+
+    private final NaverGeocodingProperties properties;
+    private final RestTemplate restTemplate;
+
+    @Override
+    public Coordinates getCoordinates(String address) throws GeocodingException {
+        final String requestUri = UriComponentsBuilder.fromUriString(properties.apiUri())
+                                                      .queryParam("query", address)
+                                                      .build(false)
+                                                      .toUriString();
+
+        final HttpEntity<Void> requestEntity = createRequestEntity();
+
+        final ResponseEntity<NaverGeocodingResponse> responseBody = restTemplate.exchange(
+                requestUri,
+                HttpMethod.GET,
+                requestEntity,
+                NaverGeocodingResponse.class
+        );
+
+        if (!responseBody.getStatusCode().is2xxSuccessful()) {
+            throw new GeocodingException("Naver Geocoding 요청에 실패했습니다.");
+        }
+
+        final AddressResponse firstAddress = extractFirstAddress(responseBody);
+
+        return firstAddress.toCoordinates();
+    }
+
+    private HttpEntity<Void> createRequestEntity() {
+        final HttpHeaders requestHeaders = new HttpHeaders();
+        requestHeaders.set("x-ncp-apigw-api-key-id", properties.clientId());
+        requestHeaders.set("x-ncp-apigw-api-key", properties.clientSecret());
+
+        return new HttpEntity<>(requestHeaders);
+    }
+
+    private AddressResponse extractFirstAddress(final ResponseEntity<NaverGeocodingResponse> responseBody) throws GeocodingException {
+        final NaverGeocodingResponse response = responseBody.getBody();
+        if (response == null || response.addresses == null || response.addresses.isEmpty()) {
+            throw new GeocodingException("Naver Geocoding에서 해당 장소를 찾을 수 없습니다.");
+        }
+
+        return response.addresses.getFirst();
+    }
+
+    record NaverGeocodingResponse (
+        String status,
+        String errorMessage,
+        List<AddressResponse> addresses
+    ) {
+    }
+
+    record AddressResponse (
+        String roadAddress,
+        String jibunAddress,
+        String englishAddress,
+        String x,
+        String y
+    ) {
+
+        public Coordinates toCoordinates() throws GeocodingException {
+            if (x == null || y == null) {
+                throw new GeocodingException("Naver Geocoding 응답에 좌표 정보가 없습니다.");
+            }
+
+            final double latitude = Double.parseDouble(y);
+            final double longitude = Double.parseDouble(x);
+
+            return new Coordinates(latitude, longitude);
+        }
+    }
+}

--- a/src/main/java/com/newworld/saegil/location/naver/NaverGeocodingHandler.java
+++ b/src/main/java/com/newworld/saegil/location/naver/NaverGeocodingHandler.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.location.naver;
 
+import com.newworld.saegil.location.Address;
 import com.newworld.saegil.location.Coordinates;
 import com.newworld.saegil.location.GeocodingException;
 import com.newworld.saegil.location.GeocodingHandler;
@@ -22,7 +23,7 @@ public class NaverGeocodingHandler implements GeocodingHandler {
     private final RestTemplate restTemplate;
 
     @Override
-    public Coordinates getCoordinates(String address) throws GeocodingException {
+    public Address getAddress(String address) throws GeocodingException {
         final String requestUri = UriComponentsBuilder.fromUriString(properties.apiUri())
                                                       .queryParam("query", address)
                                                       .build(false)
@@ -43,7 +44,7 @@ public class NaverGeocodingHandler implements GeocodingHandler {
 
         final AddressResponse firstAddress = extractFirstAddress(responseBody);
 
-        return firstAddress.toCoordinates();
+        return firstAddress.toAddress();
     }
 
     private HttpEntity<Void> createRequestEntity() {
@@ -78,15 +79,16 @@ public class NaverGeocodingHandler implements GeocodingHandler {
         String y
     ) {
 
-        public Coordinates toCoordinates() throws GeocodingException {
+        public Address toAddress() throws GeocodingException {
             if (x == null || y == null) {
                 throw new GeocodingException("Naver Geocoding 응답에 좌표 정보가 없습니다.");
             }
 
             final double latitude = Double.parseDouble(y);
             final double longitude = Double.parseDouble(x);
+            final Coordinates coordinates = new Coordinates(latitude, longitude);
 
-            return new Coordinates(latitude, longitude);
+            return new Address(roadAddress, jibunAddress, coordinates);
         }
     }
 }

--- a/src/main/java/com/newworld/saegil/location/naver/NaverGeocodingProperties.java
+++ b/src/main/java/com/newworld/saegil/location/naver/NaverGeocodingProperties.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.location.naver;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "geocoding.naver")
+public record NaverGeocodingProperties(
+        String clientId,
+        String clientSecret,
+        String apiUri
+) {
+}

--- a/src/main/java/com/newworld/saegil/location/naver/NaverLocalSearchHandler.java
+++ b/src/main/java/com/newworld/saegil/location/naver/NaverLocalSearchHandler.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.location.naver;
 
+import com.newworld.saegil.location.Address;
 import com.newworld.saegil.location.Coordinates;
 import com.newworld.saegil.location.LocationSearchException;
 import com.newworld.saegil.location.LocalSearchHandler;
@@ -22,7 +23,7 @@ public class NaverLocalSearchHandler implements LocalSearchHandler {
     private final RestTemplate restTemplate;
 
     @Override
-    public Coordinates getCoordinates(String placeName) throws LocationSearchException {
+    public Address getAddress(String placeName) throws LocationSearchException {
         final String requestUri = UriComponentsBuilder.fromUriString(properties.apiUri())
                                                       .queryParam("query", placeName)
                                                       .queryParam("display", 1)
@@ -44,7 +45,7 @@ public class NaverLocalSearchHandler implements LocalSearchHandler {
 
         final NaverLocationSearchItem firstItem = extractFirstItem(responseBody);
 
-        return firstItem.toCoordinates();
+        return firstItem.toAddress();
     }
 
     private HttpEntity<Void> createRequestEntity() {
@@ -79,15 +80,16 @@ public class NaverLocalSearchHandler implements LocalSearchHandler {
             String mapy
     ) {
 
-        public Coordinates toCoordinates() throws LocationSearchException {
+        public Address toAddress() throws LocationSearchException {
             if (mapx == null || mapy == null) {
                 throw new LocationSearchException("Naver Location Search 응답에 좌표 정보가 없습니다.");
             }
 
             final double latitude = Double.parseDouble(mapy) / 10_000_000.0;
             final double longitude = Double.parseDouble(mapx) / 10_000_000.0;
+            final Coordinates coordinates = new Coordinates(latitude, longitude);
 
-            return new Coordinates(latitude, longitude);
+            return new Address(roadAddress, address, coordinates);
         }
     }
 }

--- a/src/main/java/com/newworld/saegil/location/naver/NaverLocalSearchHandler.java
+++ b/src/main/java/com/newworld/saegil/location/naver/NaverLocalSearchHandler.java
@@ -1,0 +1,93 @@
+package com.newworld.saegil.location.naver;
+
+import com.newworld.saegil.location.Coordinates;
+import com.newworld.saegil.location.LocationSearchException;
+import com.newworld.saegil.location.LocalSearchHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NaverLocalSearchHandler implements LocalSearchHandler {
+
+    private final NaverLocationSearchProperties properties;
+    private final RestTemplate restTemplate;
+
+    @Override
+    public Coordinates getCoordinates(String placeName) throws LocationSearchException {
+        final String requestUri = UriComponentsBuilder.fromUriString(properties.apiUri())
+                                                      .queryParam("query", placeName)
+                                                      .queryParam("display", 1)
+                                                      .build(false)
+                                                      .toUriString();
+
+        final HttpEntity<Void> requestEntity = createRequestEntity();
+
+        final ResponseEntity<NaverLocationSearchResponse> responseBody = restTemplate.exchange(
+                requestUri,
+                HttpMethod.GET,
+                requestEntity,
+                NaverLocationSearchResponse.class
+        );
+
+        if (!responseBody.getStatusCode().is2xxSuccessful()) {
+            throw new LocationSearchException("Naver Loocation Search 요청에 실패했습니다.");
+        }
+
+        final NaverLocationSearchItem firstItem = extractFirstItem(responseBody);
+
+        return firstItem.toCoordinates();
+    }
+
+    private HttpEntity<Void> createRequestEntity() {
+        final HttpHeaders requestHeaders = new HttpHeaders();
+        requestHeaders.set("X-Naver-Client-Id", properties.clientId());
+        requestHeaders.set("X-Naver-Client-Secret", properties.clientSecret());
+
+        return new HttpEntity<>(requestHeaders);
+    }
+
+    private NaverLocationSearchItem extractFirstItem(
+            final ResponseEntity<NaverLocationSearchResponse> responseBody
+    ) throws LocationSearchException {
+        final NaverLocationSearchResponse response = responseBody.getBody();
+        if (response == null || response.items == null || response.items.isEmpty()) {
+            throw new LocationSearchException("Naver Location Search에서 해당 장소를 찾을 수 없습니다.");
+        }
+
+        return response.items.getFirst();
+    }
+
+    record NaverLocationSearchResponse(
+            List<NaverLocationSearchItem> items
+    ) {
+    }
+
+    record NaverLocationSearchItem(
+            String title,
+            String address,
+            String roadAddress,
+            String mapx,
+            String mapy
+    ) {
+
+        public Coordinates toCoordinates() throws LocationSearchException {
+            if (mapx == null || mapy == null) {
+                throw new LocationSearchException("Naver Location Search 응답에 좌표 정보가 없습니다.");
+            }
+
+            final double latitude = Double.parseDouble(mapy) / 10_000_000.0;
+            final double longitude = Double.parseDouble(mapx) / 10_000_000.0;
+
+            return new Coordinates(latitude, longitude);
+        }
+    }
+}

--- a/src/main/java/com/newworld/saegil/location/naver/NaverLocationSearchProperties.java
+++ b/src/main/java/com/newworld/saegil/location/naver/NaverLocationSearchProperties.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.location.naver;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "location-search.naver")
+public record NaverLocationSearchProperties(
+        String clientId,
+        String clientSecret,
+        String apiUri
+) {
+}

--- a/src/main/java/com/newworld/saegil/organization/controller/OrganizationController.java
+++ b/src/main/java/com/newworld/saegil/organization/controller/OrganizationController.java
@@ -1,4 +1,4 @@
-package com.newworld.saegil.map.controller;
+package com.newworld.saegil.organization.controller;
 
 import com.newworld.saegil.global.swagger.ApiResponseCode;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/newworld/saegil/organization/controller/ReadOrganizationResponse.java
+++ b/src/main/java/com/newworld/saegil/organization/controller/ReadOrganizationResponse.java
@@ -1,4 +1,4 @@
-package com.newworld.saegil.map.controller;
+package com.newworld.saegil.organization.controller;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -50,6 +50,11 @@ geocoding:
     client-id: ${NCP_CLIENT_ID:ncp-client-id}
     client-secret: ${NCP_CLIENT_SECRET:ncp-client-secret}
     api-uri: ${NAVER_GEOCODING_API_URI:naver-geocoding-api-uri}
+location-search:
+  naver:
+    client-id: ${NAVER_CLIENT_ID:naver-client-id}
+    client-secret: ${NAVER_CLIENT_SECRET:naver-client-secret}
+    api-uri: ${NAVER_LOCATION_SEARCH_API_URI:naver-location-search-api-uri}
 llm:
   proxy:
     llm-server-url: ${PROXY_LLM_SERVICE_URL:http://localhost:9090}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -37,14 +37,19 @@ token:
     refresh-expired-hours: 336  # 14일
 oauth2:
   kakao:
-    admin-key: ${KAKAO_ADMIN_KEY}
-    client_id: ${KAKAO_CLIENT_ID}
-    client_secret: ${KAKAO_CLIENT_SECRET}
-    redirect_uri: ${KAKAO_REDIRECT_URI}
-    scope: ${KAKAO_SCOPE}
+    admin-key: ${KAKAO_ADMIN_KEY:kakao-admin-key}
+    client_id: ${KAKAO_CLIENT_ID:kakao-client-id}
+    client_secret: ${KAKAO_CLIENT_SECRET:kakao-client-secret}
+    redirect_uri: ${KAKAO_REDIRECT_URI:kakao-redirect-uri}
+    scope: ${KAKAO_SCOPE:kakao-scope}
 user:
   default:
-    profile-image-url: ${DEFAULT_PROFILE_IMAGE_URL}
+    profile-image-url: ${DEFAULT_PROFILE_IMAGE_URL:http://localhost:8080/images/default_profile.png}
+geocoding:
+  naver:
+    client-id: ${NCP_CLIENT_ID:ncp-client-id}
+    client-secret: ${NCP_CLIENT_SECRET:ncp-client-secret}
+    api-uri: ${NAVER_GEOCODING_API_URI:naver-geocoding-api-uri}
 llm:
   proxy:
     llm-server-url: ${PROXY_LLM_SERVICE_URL:http://localhost:9090}

--- a/src/test/java/com/newworld/saegil/location/naver/NaverGeocodingHandlerTest.java
+++ b/src/test/java/com/newworld/saegil/location/naver/NaverGeocodingHandlerTest.java
@@ -1,0 +1,28 @@
+package com.newworld.saegil.location.naver;
+
+import com.newworld.saegil.location.Coordinates;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Disabled
+class NaverGeocodingHandlerTest {
+
+    @Autowired
+    private NaverGeocodingHandler naverGeocodingHandler;
+
+    @Test
+    void testGetCoordinates() throws Exception {
+        final String address = "서울 동작구 사당로 50";
+        final Coordinates actual = naverGeocodingHandler.getCoordinates(address);
+
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).isNotNull();
+            softAssertions.assertThat(actual.getLatitude()).isEqualTo(37.4944897);
+            softAssertions.assertThat(actual.getLongitude()).isEqualTo(126.9597657);
+        });
+    }
+}

--- a/src/test/java/com/newworld/saegil/location/naver/NaverGeocodingHandlerTest.java
+++ b/src/test/java/com/newworld/saegil/location/naver/NaverGeocodingHandlerTest.java
@@ -1,11 +1,13 @@
 package com.newworld.saegil.location.naver;
 
+import com.newworld.saegil.location.Address;
 import com.newworld.saegil.location.Coordinates;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Disabled
@@ -15,14 +17,19 @@ class NaverGeocodingHandlerTest {
     private NaverGeocodingHandler naverGeocodingHandler;
 
     @Test
-    void testGetCoordinates() throws Exception {
+    void testGetAddress() throws Exception {
+        // given
         final String address = "서울 동작구 사당로 50";
-        final Coordinates actual = naverGeocodingHandler.getCoordinates(address);
+        final Address expected = new Address(
+                "서울특별시 동작구 사당로 50 숭실대학교 정보과학관",
+                "서울특별시 동작구 상도동 509 숭실대학교 정보과학관",
+                new Coordinates(37.4944897, 126.9597657)
+        );
 
-        SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual).isNotNull();
-            softAssertions.assertThat(actual.getLatitude()).isEqualTo(37.4944897);
-            softAssertions.assertThat(actual.getLongitude()).isEqualTo(126.9597657);
-        });
+        // when
+        final Address actual = naverGeocodingHandler.getAddress(address);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/newworld/saegil/location/naver/NaverLocalSearchHandlerTest.java
+++ b/src/test/java/com/newworld/saegil/location/naver/NaverLocalSearchHandlerTest.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.location.naver;
 
+import com.newworld.saegil.location.Address;
 import com.newworld.saegil.location.Coordinates;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -16,12 +17,19 @@ class NaverLocalSearchHandlerTest {
     private NaverLocalSearchHandler naverLocationSearchHandler;
 
     @Test
-    void testGetCoordinates() throws Exception {
-        final String address = "숭실대학교 정보과학관";
-        final Coordinates actual = naverLocationSearchHandler.getCoordinates(address);
+    void testGetAddress() throws Exception {
+        // given
+        final String placeName = "숭실대학교 정보과학관";
+        final Address expected = new Address(
+                "서울특별시 동작구 사당로 50",
+                "서울특별시 동작구 상도동 509",
+                new Coordinates(37.4944897, 126.9597657)
+        );
 
-        assertThat(actual).isNotNull();
-        assertThat(actual.getLatitude()).isEqualTo(37.4944897);
-        assertThat(actual.getLongitude()).isEqualTo(126.9597657);
+        // when
+        final Address actual = naverLocationSearchHandler.getAddress(placeName);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/newworld/saegil/location/naver/NaverLocalSearchHandlerTest.java
+++ b/src/test/java/com/newworld/saegil/location/naver/NaverLocalSearchHandlerTest.java
@@ -1,0 +1,27 @@
+package com.newworld.saegil.location.naver;
+
+import com.newworld.saegil.location.Coordinates;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Disabled
+class NaverLocalSearchHandlerTest {
+
+    @Autowired
+    private NaverLocalSearchHandler naverLocationSearchHandler;
+
+    @Test
+    void testGetCoordinates() throws Exception {
+        final String address = "숭실대학교 정보과학관";
+        final Coordinates actual = naverLocationSearchHandler.getCoordinates(address);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getLatitude()).isEqualTo(37.4944897);
+        assertThat(actual.getLongitude()).isEqualTo(126.9597657);
+    }
+}


### PR DESCRIPTION
# 설명
네이버와 구글 api 중 고민을 했는데, 아무래도 국내 데이터이다 보니 네이버지도가 좀 더 좋겠다는 생각을 했습니다. 
시간이 된다면 구글 api도 추가해서 비교해보면 좋을 것 같네요.

- 저희 서비스에서는 공공기관의 위도와 경도 값이 필요한데, 공공데이터포탈의 사회복지시설데이터는 위도와 경도값을 제공하지 않습니다.
- 공공데이터포탈에서 제공하는 데이터에는 주소 이름 없이 기관 이름만 있는 경우도 있어요.
- 그런데 Geocoding은 정확한 주소가 있어야 값을 반환하고, 단순히 장소 이름만으로는 검색이 불가능합니다.
- 그래서 장소 이름만으로 검색할 수 있는 검색 api를 추가로 사용할 예정입니다. 다만, 주소로 검색하는 경우보다 정확도가 떨어질 수 있어요.
- 따라서, 주소가 있는 경우 geocoding을 사용하고, 없는 경우 search api를 사용할 예정입니다.

### GeocodingHandler
- 지번주소 or 도로명주소에 해당하는 위도, 경도, 도로명주소, 지번주소 반환
- [네이버클라우드 Geocoding API](https://api.ncloud-docs.com/docs/application-maps-geocoding) 사용

### LocalSearchHandler
- 장소이름에 해당하는 위도, 경도, 도로명주소, 지번주소 반환
- [네이버 Developers의 지역 검색 API](https://developers.naver.com/docs/serviceapi/search/local/local.md#%EC%A7%80%EC%97%AD-%EA%B2%80%EC%83%89-%EA%B0%9C%EC%9A%94) 사용

### 테스트
`NaverGeocodingHandlerTest`, `NaverLocalSearchHandlerTest`에 `@Disabled` 어노테이션을 붙여놨는데 주석 처리하고 돌려보면 됩니다. (application-local.yml 환경변수 세팅해줘야해요)