### PR TITLE
feat: Swagger Custom Parameter의 값을 Authorization 헤더 값으로 설정

### DIFF
--- a/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
@@ -27,6 +27,8 @@ public class WebConfiguration implements WebMvcConfigurer {
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/")
+                .excludePathPatterns("/favicon.ico")
+                .excludePathPatterns("/error")
                 .excludePathPatterns("/v3/api-docs/**")
                 .excludePathPatterns("/swagger-ui.html")
                 .excludePathPatterns("/swagger-ui/**")

--- a/src/main/java/com/newworld/saegil/global/swagger/AuthorizationHeaderSwaggerCustomParameterFilter.java
+++ b/src/main/java/com/newworld/saegil/global/swagger/AuthorizationHeaderSwaggerCustomParameterFilter.java
@@ -1,0 +1,44 @@
+package com.newworld.saegil.global.swagger;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class AuthorizationHeaderSwaggerCustomParameterFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authorizationParameterValue = request.getHeader(
+                AuthorizationHeaderSwaggerCustomizer.AUTHORIZATION_HEADER_CUSTOM_PARAMETER_NAME
+        );
+
+        if (authorizationParameterValue != null) {
+            HttpServletRequest requestWrapper = new HttpServletRequestWrapper(request) {
+                @Override
+                public String getHeader(String name) {
+                    if (HttpHeaders.AUTHORIZATION.equalsIgnoreCase(name)) {
+                        return authorizationParameterValue;
+                    }
+                    return super.getHeader(name);
+                }
+            };
+
+            filterChain.doFilter(requestWrapper, response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/newworld/saegil/global/swagger/AuthorizationHeaderSwaggerCustomizer.java
+++ b/src/main/java/com/newworld/saegil/global/swagger/AuthorizationHeaderSwaggerCustomizer.java
@@ -18,6 +18,8 @@ import java.util.stream.Collectors;
 @Component
 public class AuthorizationHeaderSwaggerCustomizer implements OperationCustomizer {
 
+    public static final String AUTHORIZATION_HEADER_CUSTOM_PARAMETER_NAME = "Authorization-Header";
+
     @Override
     public Operation customize(Operation operation, HandlerMethod handlerMethod) {
         ignoreSwaggerParameterAboutAuthorizationHeader(operation);
@@ -77,7 +79,7 @@ public class AuthorizationHeaderSwaggerCustomizer implements OperationCustomizer
         return new Parameter()
                 .in("header")
                 .schema(new StringSchema())
-                .name("Authorization")
+                .name(AUTHORIZATION_HEADER_CUSTOM_PARAMETER_NAME)
                 .description("서비스 Access Token")
                 .required(true)
                 .example("Bearer access-token-abcdefghijklmn");


### PR DESCRIPTION
# 설명

### 문제1
- #36 에서 구현한 custom parameter에 Access Token을 작성한 후 요청을 하더라도 요청 Authorization 헤더에 값을 포함하지 않고 요청을 보냄
- 동적으로 Authorization 헤더를 설정하는 것을 차단하는 것 같음

### 해결1
- 다른 이름("Header-Authorization")으로 파라미터명 변경 --> 요청 헤더에 잘 포함됨

### 문제2
- Interceptor 등에 사용할 Access Token은 "Authorization"헤더에서만 추출하고 있음

### 해결2
- Filter를 사용해서 "Authorization-Header" 커스텀 파라미터의 값을 Authorization 헤더 getter의 반환값으로 사용