### PR TITLE
feat: 시뮬레이션 목록 및 메시지 내역 조회 api & 생성 로직 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/simulation/controller/ReadSimulationMessagesResponse.java
+++ b/src/main/java/com/newworld/saegil/simulation/controller/ReadSimulationMessagesResponse.java
@@ -1,0 +1,38 @@
+package com.newworld.saegil.simulation.controller;
+
+import com.newworld.saegil.simulation.service.MessageDto;
+import com.newworld.saegil.simulation.service.ReadMessagesResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ReadSimulationMessagesResponse(
+        String scenarioName,
+        List<ReadMessageItemResponse> messages
+) {
+
+    public static ReadSimulationMessagesResponse from(final ReadMessagesResult readMessagesResult) {
+        final String scenarioName = readMessagesResult.simulation().scenario().name();
+        final List<ReadMessageItemResponse> messages = readMessagesResult.messages().stream()
+                                                                      .map(ReadMessageItemResponse::from)
+                                                                      .toList();
+
+        return new ReadSimulationMessagesResponse(scenarioName, messages);
+    }
+
+    record ReadMessageItemResponse(
+            Long id,
+            boolean isFromUser,
+            String contents,
+            LocalDateTime createdAt
+    ) {
+        public static ReadMessageItemResponse from(final MessageDto messageDto) {
+            return new ReadMessageItemResponse(
+                    messageDto.id(),
+                    messageDto.isFromUser(),
+                    messageDto.contents(),
+                    messageDto.createdAt()
+            );
+        }
+    }
+}

--- a/src/main/java/com/newworld/saegil/simulation/controller/ReadSimulationMessagesResponse.java
+++ b/src/main/java/com/newworld/saegil/simulation/controller/ReadSimulationMessagesResponse.java
@@ -14,8 +14,8 @@ public record ReadSimulationMessagesResponse(
     public static ReadSimulationMessagesResponse from(final ReadMessagesResult readMessagesResult) {
         final String scenarioName = readMessagesResult.simulation().scenario().name();
         final List<ReadMessageItemResponse> messages = readMessagesResult.messages().stream()
-                                                                      .map(ReadMessageItemResponse::from)
-                                                                      .toList();
+                                                                         .map(ReadMessageItemResponse::from)
+                                                                         .toList();
 
         return new ReadSimulationMessagesResponse(scenarioName, messages);
     }

--- a/src/main/java/com/newworld/saegil/simulation/controller/ReadSimulationResponse.java
+++ b/src/main/java/com/newworld/saegil/simulation/controller/ReadSimulationResponse.java
@@ -1,0 +1,30 @@
+package com.newworld.saegil.simulation.controller;
+
+import com.newworld.saegil.simulation.service.SimulationDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record ReadSimulationResponse(
+        @Schema(description = "시뮬레이션 기록 식별자", example = "1")
+        Long id,
+
+        @Schema(description = "상황 이름", example = "마트에 갔을 때")
+        String scenarioName,
+
+        @Schema(description = "상황 아이콘 이미지 URL", example = "https://example.com/icon.jpg")
+        String scenarioIconImageUrl,
+
+        @Schema(description = "시뮬레이션 기록 생성 시간", example = "2025-05-05T12:00:00")
+        LocalDateTime createdAt
+) {
+
+    public static ReadSimulationResponse from(final SimulationDto simulationDto) {
+        return new ReadSimulationResponse(
+                simulationDto.id(),
+                simulationDto.scenario().name(),
+                simulationDto.scenario().iconImageUrl(),
+                simulationDto.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/simulation/controller/SimulationController.java
+++ b/src/main/java/com/newworld/saegil/simulation/controller/SimulationController.java
@@ -4,15 +4,18 @@ import com.newworld.saegil.authentication.annotation.AuthUser;
 import com.newworld.saegil.authentication.dto.AuthUserInfo;
 import com.newworld.saegil.configuration.SwaggerConfiguration;
 import com.newworld.saegil.global.swagger.ApiResponseCode;
+import com.newworld.saegil.simulation.service.ReadMessagesResult;
 import com.newworld.saegil.simulation.service.SimulationDto;
 import com.newworld.saegil.simulation.service.SimulationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,6 +41,23 @@ public class SimulationController {
         final List<ReadSimulationResponse> response = simulationDtos.stream()
                                                                     .map(ReadSimulationResponse::from)
                                                                     .toList();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{simulationId}/messages")
+    @Operation(
+            summary = "시뮬레이션 대화 메시지 내용 목록 조회",
+            description = "하나의 시뮬레이션 대화 메시지 내용 목록을 조회합니다.",
+            security = @SecurityRequirement(name = SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)
+    )
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "시뮬레이션 대화 메시지 내용 목록 조회 성공")
+    public ResponseEntity<ReadSimulationMessagesResponse> readAllMessagesBySimulationId(
+            @Parameter(description = "시뮬레이션 기록 식별자", example = "1")
+            @PathVariable final Long simulationId
+    ) {
+        final ReadMessagesResult result = simulationService.readAllMessagesBySimulationId(simulationId);
+        final ReadSimulationMessagesResponse response = ReadSimulationMessagesResponse.from(result);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/newworld/saegil/simulation/controller/SimulationController.java
+++ b/src/main/java/com/newworld/saegil/simulation/controller/SimulationController.java
@@ -1,0 +1,44 @@
+package com.newworld.saegil.simulation.controller;
+
+import com.newworld.saegil.authentication.annotation.AuthUser;
+import com.newworld.saegil.authentication.dto.AuthUserInfo;
+import com.newworld.saegil.configuration.SwaggerConfiguration;
+import com.newworld.saegil.global.swagger.ApiResponseCode;
+import com.newworld.saegil.simulation.service.SimulationDto;
+import com.newworld.saegil.simulation.service.SimulationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/simulations")
+@RequiredArgsConstructor
+@Tag(name = "Simulation", description = "시뮬레이션 기록 API")
+public class SimulationController {
+
+    private final SimulationService simulationService;
+
+    @GetMapping
+    @Operation(
+            summary = "시뮬레이션 기록 목록 조회",
+            description = "시뮬레이션 기록 목록을 조회합니다.",
+            security = @SecurityRequirement(name = SwaggerConfiguration.SERVICE_SECURITY_SCHEME_NAME)
+    )
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "시뮬레이션 기록 목록 조회 성공")
+    public ResponseEntity<List<ReadSimulationResponse>> readAllSimulations(@AuthUser final AuthUserInfo authUserInfo) {
+        final List<SimulationDto> simulationDtos = simulationService.readAllSimulationHistories(authUserInfo.userId());
+        final List<ReadSimulationResponse> response = simulationDtos.stream()
+                                                                    .map(ReadSimulationResponse::from)
+                                                                    .toList();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/newworld/saegil/simulation/domain/Message.java
+++ b/src/main/java/com/newworld/saegil/simulation/domain/Message.java
@@ -42,9 +42,13 @@ public class Message {
     private LocalDateTime createdAt;
 
     public Message(final Simulation simulation, final boolean isFromUser, final String contents, final LocalDateTime createdAt) {
+        if (contents.length() > 16000) {
+            this.contents = contents.substring(0, 15990).concat("...");
+        } else {
+            this.contents = contents;
+        }
         this.simulation = simulation;
         this.isFromUser = isFromUser;
-        this.contents = contents;
         this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/newworld/saegil/simulation/domain/Message.java
+++ b/src/main/java/com/newworld/saegil/simulation/domain/Message.java
@@ -1,0 +1,43 @@
+package com.newworld.saegil.simulation.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+@ToString(of = {"id", "isFromUser", "contents", "createdAt"})
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "simulation_id", nullable = false, foreignKey = @ForeignKey(name = "fk_message_simulation"))
+    private Simulation simulation;
+
+    @Column(nullable = false)
+    private boolean isFromUser;
+
+    @Column(nullable = false, length = 20_000) // TODO: 길이제한 몇으로 할까
+    private String contents;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/newworld/saegil/simulation/domain/Message.java
+++ b/src/main/java/com/newworld/saegil/simulation/domain/Message.java
@@ -40,4 +40,11 @@ public class Message {
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    public Message(final Simulation simulation, final boolean isFromUser, final String contents, final LocalDateTime createdAt) {
+        this.simulation = simulation;
+        this.isFromUser = isFromUser;
+        this.contents = contents;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/newworld/saegil/simulation/domain/Message.java
+++ b/src/main/java/com/newworld/saegil/simulation/domain/Message.java
@@ -35,7 +35,7 @@ public class Message {
     @Column(nullable = false)
     private boolean isFromUser;
 
-    @Column(nullable = false, length = 20_000) // TODO: 길이제한 몇으로 할까
+    @Column(nullable = false, length = 16000)
     private String contents;
 
     @Column(nullable = false)

--- a/src/main/java/com/newworld/saegil/simulation/domain/Simulation.java
+++ b/src/main/java/com/newworld/saegil/simulation/domain/Simulation.java
@@ -43,4 +43,11 @@ public class Simulation {
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    public Simulation(final Scenario scenario, final User user, final String threadId, final LocalDateTime createdAt) {
+        this.scenario = scenario;
+        this.user = user;
+        this.threadId = threadId;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/newworld/saegil/simulation/domain/Simulation.java
+++ b/src/main/java/com/newworld/saegil/simulation/domain/Simulation.java
@@ -1,0 +1,46 @@
+package com.newworld.saegil.simulation.domain;
+
+import com.newworld.saegil.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+@ToString(of = {"id", "createdAt"})
+@Table(name = "simulation")
+public class Simulation {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "scenario_id", nullable = false, foreignKey = @ForeignKey(name = "fk_simulation_scenario"))
+    private Scenario scenario;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_simulation_user"))
+    private User user;
+
+    @Column(nullable = false)
+    private String threadId;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/newworld/saegil/simulation/repository/MessageRepository.java
+++ b/src/main/java/com/newworld/saegil/simulation/repository/MessageRepository.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.simulation.repository;
+
+import com.newworld.saegil.simulation.domain.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    List<Message> findAllBySimulationId(final Long simulationId);
+}

--- a/src/main/java/com/newworld/saegil/simulation/repository/SimulationRepository.java
+++ b/src/main/java/com/newworld/saegil/simulation/repository/SimulationRepository.java
@@ -1,0 +1,13 @@
+package com.newworld.saegil.simulation.repository;
+
+import com.newworld.saegil.simulation.domain.Simulation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SimulationRepository extends JpaRepository<Simulation, Long> {
+
+    List<Simulation> findAllByUserId(final Long userId);
+}

--- a/src/main/java/com/newworld/saegil/simulation/repository/SimulationRepository.java
+++ b/src/main/java/com/newworld/saegil/simulation/repository/SimulationRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SimulationRepository extends JpaRepository<Simulation, Long> {
 
+    Optional<Simulation> findByThreadIdAndUserId(final String threadId, final Long userId);
     List<Simulation> findAllByUserId(final Long userId);
 }

--- a/src/main/java/com/newworld/saegil/simulation/service/CreateMessageResult.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/CreateMessageResult.java
@@ -1,0 +1,8 @@
+package com.newworld.saegil.simulation.service;
+
+public record CreateMessageResult(
+        String threadId,
+        String userQuestion,
+        String assistantAnswer
+) {
+}

--- a/src/main/java/com/newworld/saegil/simulation/service/MessageDto.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/MessageDto.java
@@ -1,0 +1,23 @@
+package com.newworld.saegil.simulation.service;
+
+import com.newworld.saegil.simulation.domain.Message;
+
+import java.time.LocalDateTime;
+
+public record MessageDto(
+        Long id,
+        Long simulationId,
+        boolean isFromUser,
+        String contents,
+        LocalDateTime createdAt
+) {
+    public static MessageDto from(Message message) {
+        return new MessageDto(
+                message.getId(),
+                message.getSimulation().getId(),
+                message.isFromUser(),
+                message.getContents(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/simulation/service/ReadMessagesResult.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/ReadMessagesResult.java
@@ -1,0 +1,27 @@
+package com.newworld.saegil.simulation.service;
+
+import com.newworld.saegil.simulation.domain.Message;
+import com.newworld.saegil.simulation.domain.Simulation;
+
+import java.util.List;
+
+public record ReadMessagesResult(
+        SimulationDto simulation,
+        List<MessageDto> messages
+) {
+
+    public static ReadMessagesResult from(
+            final Simulation simulation,
+            final List<Message> messages
+    ) {
+        final SimulationDto simulationDto = SimulationDto.from(simulation);
+        final List<MessageDto> messageDtos = messages.stream()
+                                                     .map(MessageDto::from)
+                                                     .toList();
+
+        return new ReadMessagesResult(
+                simulationDto,
+                messageDtos
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/simulation/service/ScenarioNotFoundException.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/ScenarioNotFoundException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.simulation.service;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class ScenarioNotFoundException extends CustomException {
+
+    public ScenarioNotFoundException(final String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/newworld/saegil/simulation/service/SimulationDto.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/SimulationDto.java
@@ -1,0 +1,22 @@
+package com.newworld.saegil.simulation.service;
+
+import com.newworld.saegil.simulation.domain.Simulation;
+
+import java.time.LocalDateTime;
+
+public record SimulationDto(
+        Long id,
+        ScenarioDto scenario,
+        Long userId,
+        LocalDateTime createdAt
+) {
+
+    public static SimulationDto from(final Simulation simulation) {
+        return new SimulationDto(
+                simulation.getId(),
+                ScenarioDto.from(simulation.getScenario()),
+                simulation.getUser().getId(),
+                simulation.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/simulation/service/SimulationNotFoundException.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/SimulationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.simulation.service;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class SimulationNotFoundException extends CustomException {
+
+    public SimulationNotFoundException(final String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/newworld/saegil/simulation/service/SimulationService.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/SimulationService.java
@@ -2,8 +2,10 @@ package com.newworld.saegil.simulation.service;
 
 import com.newworld.saegil.exception.UserNotFoundException;
 import com.newworld.saegil.simulation.domain.Message;
+import com.newworld.saegil.simulation.domain.Scenario;
 import com.newworld.saegil.simulation.domain.Simulation;
 import com.newworld.saegil.simulation.repository.MessageRepository;
+import com.newworld.saegil.simulation.repository.ScenarioRepository;
 import com.newworld.saegil.simulation.repository.SimulationRepository;
 import com.newworld.saegil.user.domain.User;
 import com.newworld.saegil.user.repository.UserRepository;
@@ -11,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -19,6 +22,7 @@ import java.util.List;
 public class SimulationService {
 
     private final UserRepository userRepository;
+    private final ScenarioRepository scenarioRepository;
     private final SimulationRepository simulationRepository;
     private final MessageRepository messageRepository;
 
@@ -41,5 +45,39 @@ public class SimulationService {
         final List<Message> messages = messageRepository.findAllBySimulationId(simulation.getId());
 
         return ReadMessagesResult.from(simulation, messages);
+    }
+
+    public CreateMessageResult createMessageCycle(
+            final String threadId,
+            final Long scenarioId,
+            final Long userId,
+            final String userQuestion,
+            final String assistantAnswer
+    ) {
+        final User user = userRepository.findById(userId)
+                                        .orElseThrow(() -> new UserNotFoundException("사용자가 존재하지 않습니다."));
+
+        final Simulation simulation = simulationRepository.findByThreadIdAndUserId(threadId, userId)
+                                                          .orElseGet(() -> createSimulation(threadId, scenarioId, user));
+        final Message userQuestionMessage = new Message(simulation, true, userQuestion, LocalDateTime.now());
+        messageRepository.save(userQuestionMessage);
+        final Message assistantAnswerMessage = new Message(simulation, false, assistantAnswer, LocalDateTime.now());
+        messageRepository.save(assistantAnswerMessage);
+
+        return new CreateMessageResult(threadId, userQuestion, assistantAnswer);
+    }
+
+    private Simulation createSimulation(
+            final String threadId,
+            final Long scenarioId,
+            final User user
+    ) {
+        final Scenario scenario = scenarioRepository.findById(scenarioId)
+                                                    .orElseThrow(() ->
+                                                            new ScenarioNotFoundException("시나리오가 존재하지 않습니다.")
+                                                    );
+        final Simulation newSimulation = new Simulation(scenario, user, threadId, LocalDateTime.now());
+
+        return simulationRepository.save(newSimulation);
     }
 }

--- a/src/main/java/com/newworld/saegil/simulation/service/SimulationService.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/SimulationService.java
@@ -1,6 +1,9 @@
 package com.newworld.saegil.simulation.service;
 
 import com.newworld.saegil.exception.UserNotFoundException;
+import com.newworld.saegil.simulation.domain.Message;
+import com.newworld.saegil.simulation.domain.Simulation;
+import com.newworld.saegil.simulation.repository.MessageRepository;
 import com.newworld.saegil.simulation.repository.SimulationRepository;
 import com.newworld.saegil.user.domain.User;
 import com.newworld.saegil.user.repository.UserRepository;
@@ -17,6 +20,7 @@ public class SimulationService {
 
     private final UserRepository userRepository;
     private final SimulationRepository simulationRepository;
+    private final MessageRepository messageRepository;
 
     public List<SimulationDto> readAllSimulationHistories(final Long userId) {
         final User user = userRepository.findById(userId)
@@ -26,5 +30,16 @@ public class SimulationService {
                                    .stream()
                                    .map(SimulationDto::from)
                                    .toList();
+    }
+
+    public ReadMessagesResult readAllMessagesBySimulationId(final Long simulationId) {
+        final Simulation simulation =
+                simulationRepository.findById(simulationId)
+                                    .orElseThrow(() ->
+                                            new SimulationNotFoundException("해당하는 시뮬레이션 기록을 찾을 수 없습니다.")
+                                    );
+        final List<Message> messages = messageRepository.findAllBySimulationId(simulation.getId());
+
+        return ReadMessagesResult.from(simulation, messages);
     }
 }

--- a/src/main/java/com/newworld/saegil/simulation/service/SimulationService.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/SimulationService.java
@@ -1,0 +1,30 @@
+package com.newworld.saegil.simulation.service;
+
+import com.newworld.saegil.exception.UserNotFoundException;
+import com.newworld.saegil.simulation.repository.SimulationRepository;
+import com.newworld.saegil.user.domain.User;
+import com.newworld.saegil.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SimulationService {
+
+    private final UserRepository userRepository;
+    private final SimulationRepository simulationRepository;
+
+    public List<SimulationDto> readAllSimulationHistories(final Long userId) {
+        final User user = userRepository.findById(userId)
+                                        .orElseThrow(() -> new UserNotFoundException("사용자가 존재하지 않습니다."));
+
+        return simulationRepository.findAllByUserId(user.getId())
+                                   .stream()
+                                   .map(SimulationDto::from)
+                                   .toList();
+    }
+}


### PR DESCRIPTION
# 설명
- fast api 서버에서 데이터 받은 후 SimulationService.createMessageCycle()을 호출해서 메시지를 저장하면 됩니다.
- threadId와 userId로 Simulation(대화 기록)이 있는지 조회한 후 없다면 Simulation 엔티티를 생성합니다.