### PR TITLE
refactor: 시설 크롤링 로깅 오류 수정 및 예외 처리 강화

### DIFF
--- a/src/main/java/com/newworld/saegil/facility/domain/Facility.java
+++ b/src/main/java/com/newworld/saegil/facility/domain/Facility.java
@@ -59,9 +59,7 @@ public class Facility {
             final String name,
             final String telephoneNumber,
             final String roadAddress,
-            final String jibunAddress,
-            final Double latitude,
-            final Double longitude
+            final String jibunAddress
     ) {
         this.name = name.trim();
         this.facilityCode = facilityCode.trim();
@@ -69,8 +67,8 @@ public class Facility {
         this.telephoneNumber = telephoneNumber.trim();
         this.roadAddress = roadAddress.trim();
         this.jibunAddress = jibunAddress.trim();
-        this.latitude = latitude;
-        this.longitude = longitude;
+        this.latitude = null;
+        this.longitude = null;
     }
 
     public void updateLocationInfo(final LocationInfo locationInfo) {

--- a/src/main/java/com/newworld/saegil/facility/domain/Facility.java
+++ b/src/main/java/com/newworld/saegil/facility/domain/Facility.java
@@ -53,6 +53,9 @@ public class Facility {
     @Column
     private Double longitude;
 
+    @Column
+    private String errorMessage;
+
     public Facility(
             final String facilityCode,
             final FacilityInfoSource infoSource,
@@ -69,6 +72,7 @@ public class Facility {
         this.jibunAddress = jibunAddress.trim();
         this.latitude = null;
         this.longitude = null;
+        this.errorMessage = null;
     }
 
     public void updateLocationInfo(final LocationInfo locationInfo) {
@@ -84,5 +88,19 @@ public class Facility {
         }
 
         return roadAddress;
+    }
+
+    public void markError(final Exception exception) {
+        if (exception == null) {
+            return;
+        }
+
+        final String exceptionMeesage = exception.getClass().getSimpleName() + ": " + exception.getMessage();
+
+        if (exceptionMeesage.length() > 250) {
+            this.errorMessage = exceptionMeesage.substring(0, 250) + "...";
+        } else {
+            this.errorMessage = exceptionMeesage;
+        }
     }
 }

--- a/src/main/java/com/newworld/saegil/facility/service/FacilityCrawlingService.java
+++ b/src/main/java/com/newworld/saegil/facility/service/FacilityCrawlingService.java
@@ -58,6 +58,8 @@ public class FacilityCrawlingService {
                 facility.updateLocationInfo(locationInfo);
             } catch (final LocationInfoResolveFailedException e) {
                 log.error("시설({})의 위치 좌표를 찾을 수 없습니다: {}", facility.getName(), e.getMessage());
+            } catch (final Exception e) {
+                log.error("시설({})의 위치 좌표를 찾는 중 알 수 없는 오류가 발생했습니다: {}", facility.getName(), e.getMessage());
             }
         }
         final long locationInfoResolveEndTime = System.currentTimeMillis();

--- a/src/main/java/com/newworld/saegil/facility/service/FacilityCrawlingService.java
+++ b/src/main/java/com/newworld/saegil/facility/service/FacilityCrawlingService.java
@@ -73,7 +73,7 @@ public class FacilityCrawlingService {
                 totalCrawledFacilities.size(), infoSource.getName(), crawlEndTime - crawlStartTime
         );
         log.info("{}개의 새로운 {} 좌표 찾기 소요 시간: {} ms",
-                newFacilitiesToSave, infoSource.getName(), locationInfoResolveEndTime - locationInfoResolveStartTime
+                newFacilitiesToSave.size(), infoSource.getName(), locationInfoResolveEndTime - locationInfoResolveStartTime
         );
         log.info("{}개의 새로운 {} 저장 소요 시간: {} ms",
                 newFacilitiesToSave.size(), infoSource.getName(), saveEndTime - saveStartTime

--- a/src/main/java/com/newworld/saegil/facility/service/FacilityCrawlingService.java
+++ b/src/main/java/com/newworld/saegil/facility/service/FacilityCrawlingService.java
@@ -57,8 +57,10 @@ public class FacilityCrawlingService {
 
                 facility.updateLocationInfo(locationInfo);
             } catch (final LocationInfoResolveFailedException e) {
+                facility.markError(e);
                 log.error("시설({})의 위치 좌표를 찾을 수 없습니다: {}", facility.getName(), e.getMessage());
             } catch (final Exception e) {
+                facility.markError(e);
                 log.error("시설({})의 위치 좌표를 찾는 중 알 수 없는 오류가 발생했습니다: {}", facility.getName(), e.getMessage());
             }
         }

--- a/src/main/java/com/newworld/saegil/facility/service/crawler/NationalSocialWelfareFacilityCrawler.java
+++ b/src/main/java/com/newworld/saegil/facility/service/crawler/NationalSocialWelfareFacilityCrawler.java
@@ -136,9 +136,7 @@ public class NationalSocialWelfareFacilityCrawler implements FacilityCrawler {
                     fcltNm,
                     fcltTelno,
                     address,
-                    address,
-                    null,
-                    null
+                    address
             );
         }
     }

--- a/src/main/java/com/newworld/saegil/facility/service/crawler/NationalSocialWelfareFacilityCrawler.java
+++ b/src/main/java/com/newworld/saegil/facility/service/crawler/NationalSocialWelfareFacilityCrawler.java
@@ -41,21 +41,18 @@ public class NationalSocialWelfareFacilityCrawler implements FacilityCrawler {
         final List<Facility> totalFacilities = new ArrayList<>();
         while (true) {
             final URI requestUri = createRequestUri(page);
-            try {
-                final NationalSocialWelfareFacilityResponse response =
-                        restTemplate.getForObject(requestUri, NationalSocialWelfareFacilityResponse.class);
-                if (response.isItemEmpty()) {
-                    break;
-                }
-
-                final List<Facility> facilities = response.getItems()
-                                                          .stream()
-                                                          .map(Item::toFacility)
-                                                          .toList();
-                totalFacilities.addAll(facilities);
-            } catch (Exception e) {
-                log.error("Error occurred while fetching page({}): {}", page, e.getMessage());
+            final NationalSocialWelfareFacilityResponse response =
+                    restTemplate.getForObject(requestUri, NationalSocialWelfareFacilityResponse.class);
+            if (response.isItemEmpty()) {
+                break;
             }
+
+            final List<Facility> facilities = response.getItems()
+                                                      .stream()
+                                                      .map(Item::toFacility)
+                                                      .toList();
+            totalFacilities.addAll(facilities);
+
             page++;
         }
 


### PR DESCRIPTION
# 설명
- 시설 크롤링 시 리스트 개수를 로깅해야 하는데 리스트 요소를 로깅하는 부분을 수정했습니다.
- 개발 서버에서 실행 중 위/경도 변환 과정에서 로컬에서는 발생하지 않았던 문제로 인해 중간에 멈추는 문제가 있었어요. 오류 원인은 `400 Bad Request on GET request for "https://openapi.naver.com/v1/search/local.json": "{<EOL>?"errorMessage":"Incorrect query request (잘못된 쿼리요청입니다.)",<EOL>?"errorCode":"SE01"<EOL>}"` 입니다. 이건 커스텀Exception 발생 상황이 아니라 최상위 예외 클래스인 Exception으로 핸들링 할 수 있도록 catch문을 추가했어요
- 데이터가 많아서 로그만으로 파악하기 힘들고, 추후 원인 분석 및 재시도를 위해 예외 종류와 메시지를 facility 엔티티에 함께 저장하도록 했습니다.