### PR TITLE
feat: 음성 파일 업로드를 통한 Assistant 응답 기능 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/llm/config/ProxyProperties.java
+++ b/src/main/java/com/newworld/saegil/llm/config/ProxyProperties.java
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "llm.proxy")
 public record ProxyProperties(
-    String assistantAudioFromFilePath
+    String assistantAudioFromFilePath,
+    String assistantUploadPath
 ) {
 }

--- a/src/main/java/com/newworld/saegil/llm/model/AssistantResponse.java
+++ b/src/main/java/com/newworld/saegil/llm/model/AssistantResponse.java
@@ -1,0 +1,24 @@
+package com.newworld.saegil.llm.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class AssistantResponse {
+    @JsonProperty("question")
+    private String question;
+
+    @JsonProperty("response")
+    private String response;
+
+    @JsonProperty("threadId")
+    private String threadId;
+} 

--- a/src/main/java/com/newworld/saegil/llm/service/AssistantService.java
+++ b/src/main/java/com/newworld/saegil/llm/service/AssistantService.java
@@ -1,8 +1,11 @@
 package com.newworld.saegil.llm.service;
 
+import com.newworld.saegil.llm.model.AssistantResponse;
 import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AssistantService {
     Resource getAssistantAudioResponseFromAudioFile(final MultipartFile multipartFile, final String threadId, final String provider);
+    
+    AssistantResponse getAssistantResponseFromAudioFile(final MultipartFile multipartFile, final String threadId);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -71,6 +71,7 @@ llm:
   proxy:
     llm-server-url: ${PROXY_LLM_SERVICE_URL:http://localhost:9090}
     assistant-audio-from-file-path: ${llm.proxy.llm-server-url}/api/v1/assistant/upload/audio
+    assistant-upload-path: ${llm.proxy.llm-server-url}/api/v1/assistant/upload
   file:
     result-file-name: assistant_response.mp3
 logging:


### PR DESCRIPTION
# 설명

## 문제점

- 멀티파트가 아닌 음성파일과 텍스트 파일을 하나의 응답으로 클라이언트에게 전달을 할 수 없더라구요.
- 그래서 해결방법으로 음성파일을 업로드하면 해당 음성파일의 답변을 `thread_id`와 함께 텍스트로 전달합니다.
- 추후 개설되는 엔드포인트로 클라이언트에서 텍스트를 음성파일로 변환하는 요청을 연속적으로 보내도록 문제를 해결했어요.
- 즉, 음성파일 -> Assistant의 텍스트 답변, thread_id -> 텍스트 답변을 TTS로 요청 -> 음성파일을 반환으로 흘러갑니다.