### PR TITLE
refactor: .gitignore 파일 정리 및 불필요한 항목 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,11 +34,7 @@ out/
 /.nb-gradle/
 
 ### VS Code ###
-.vscode/
-
-### Copilot ###
-copilot-instructions.md
-.github/prompts/
+/.vscode/
 
 ### macOS ###
 .DS_Store
@@ -48,9 +44,3 @@ copilot-instructions.md
 
 ### MP3 Files ###
 *.mp3
-
-### Junie ###
-.junie/
-
-### cursor ###
-*.mdc


### PR DESCRIPTION
Junie, Cursor, Windsurf, GitHub Copilot는 저만 사용하는 파일이라서 `.git/info/exclude`에 넣었습니다.
위의 기능은 로컬 gitignore와 같은 파일이더라구요?
gitignore도 공용적으로만 불필요한 파일들을 넣으면 되는 것이라서 되게 신기했습니다.