### PR TITLE
refactor: Simulation 엔티티에 불필요한 User 엔티티 연관관계 제거 (id로 변경)

### DIFF
--- a/src/main/java/com/newworld/saegil/simulation/domain/Simulation.java
+++ b/src/main/java/com/newworld/saegil/simulation/domain/Simulation.java
@@ -1,6 +1,5 @@
 package com.newworld.saegil.simulation.domain;
 
-import com.newworld.saegil.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -35,9 +34,8 @@ public class Simulation {
     @JoinColumn(name = "scenario_id", nullable = false, foreignKey = @ForeignKey(name = "fk_simulation_scenario"))
     private Scenario scenario;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_simulation_user"))
-    private User user;
+    @Column(nullable = false)
+    private Long userId;
 
     @Column(nullable = false)
     private String threadId;
@@ -45,9 +43,9 @@ public class Simulation {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    public Simulation(final Scenario scenario, final User user, final String threadId, final LocalDateTime createdAt) {
+    public Simulation(final Scenario scenario, Long userId, final String threadId, final LocalDateTime createdAt) {
         this.scenario = scenario;
-        this.user = user;
+        this.userId = userId;
         this.threadId = threadId;
         this.createdAt = createdAt;
     }

--- a/src/main/java/com/newworld/saegil/simulation/service/SimulationDto.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/SimulationDto.java
@@ -15,7 +15,7 @@ public record SimulationDto(
         return new SimulationDto(
                 simulation.getId(),
                 ScenarioDto.from(simulation.getScenario()),
-                simulation.getUser().getId(),
+                simulation.getUserId(),
                 simulation.getCreatedAt()
         );
     }

--- a/src/main/java/com/newworld/saegil/simulation/service/SimulationService.java
+++ b/src/main/java/com/newworld/saegil/simulation/service/SimulationService.java
@@ -76,7 +76,7 @@ public class SimulationService {
                                                     .orElseThrow(() ->
                                                             new ScenarioNotFoundException("시나리오가 존재하지 않습니다.")
                                                     );
-        final Simulation newSimulation = new Simulation(scenario, user, threadId, LocalDateTime.now());
+        final Simulation newSimulation = new Simulation(scenario, user.getId(), threadId, LocalDateTime.now());
 
         return simulationRepository.save(newSimulation);
     }


### PR DESCRIPTION
# 설명
별 거 아니긴 한데 Simulation에서 User를 들고 있으면 service 레이어에서 리턴할 때 dto 만들다보면 추가 쿼리가 발생하거나, 이를 방지하기 위해 fetch type을 eager로 해서 한 번에 조회하거나 해야 하는데 저희 요구사항에서는 굳이 엔티티로 들고 있지 않아도 될 것 같아서 userId만 들고 있도록 수정했습니다. 