### PR TITLE
feat: 서울열린데이터광장 서울시일자리포털 채용 정보 및 근무지 위/경도 저장 기능 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
@@ -1,0 +1,58 @@
+package com.newworld.saegil.recruitment.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+@ToString
+@Table(name = "recruitment")
+public class Recruitment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String recruitmentCode;
+
+    @Column(nullable = false)
+    private RecruitmentInfoSource infoSource;
+
+    @Column(nullable = false)
+    private String name;
+
+    private LocalDateTime recruitmentStartDate;
+
+    private LocalDateTime recruitmentEndDate;
+
+    private String weeklyWorkdays;
+
+    private String workTime;
+
+    private String pay;
+
+    private String webLink;
+
+    private String roadAddress;
+
+    private String jibunAddress;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private String errorMessage;
+}

--- a/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.recruitment.domain;
 
+import com.newworld.saegil.location.LocationInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -70,13 +71,35 @@ public class Recruitment {
     ) {
         this.recruitmentCode = recruitmentCode;
         this.infoSource = infoSource;
-        this.name = name;
+        this.name = name.trim();
         this.recruitmentStartDate = recruitmentStartDate;
         this.recruitmentEndDate = recruitmentEndDate;
-        this.weeklyWorkdays = weeklyWorkdays;
-        this.workTime = workTime;
-        this.pay = pay;
+        this.weeklyWorkdays = weeklyWorkdays.trim();
+        this.workTime = workTime.trim();
+        this.pay = pay.trim();
         this.webLink = webLink;
-        this.roadAddress = roadAddress;
+        this.roadAddress = roadAddress.trim();
+    }
+
+    public void updateLocationInfo(final LocationInfo locationInfo) {
+        this.roadAddress = locationInfo.roadAddress();
+        this.jibunAddress = locationInfo.jibunAddress();
+        this.latitude = locationInfo.getLatitude();
+        this.longitude = locationInfo.getLongitude();
+    }
+
+
+    public void markError(final Exception exception) {
+        if (exception == null) {
+            return;
+        }
+
+        final String exceptionMeesage = exception.getClass().getSimpleName() + ": " + exception.getMessage();
+
+        if (exceptionMeesage.length() > 250) {
+            this.errorMessage = exceptionMeesage.substring(0, 250) + "...";
+        } else {
+            this.errorMessage = exceptionMeesage;
+        }
     }
 }

--- a/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
@@ -55,4 +55,28 @@ public class Recruitment {
     private Double longitude;
 
     private String errorMessage;
+
+    public Recruitment(
+            final String recruitmentCode,
+            final RecruitmentInfoSource infoSource,
+            final String name,
+            final LocalDateTime recruitmentStartDate,
+            final LocalDateTime recruitmentEndDate,
+            final String weeklyWorkdays,
+            final String workTime,
+            final String pay,
+            final String webLink,
+            final String roadAddress
+    ) {
+        this.recruitmentCode = recruitmentCode;
+        this.infoSource = infoSource;
+        this.name = name;
+        this.recruitmentStartDate = recruitmentStartDate;
+        this.recruitmentEndDate = recruitmentEndDate;
+        this.weeklyWorkdays = weeklyWorkdays;
+        this.workTime = workTime;
+        this.pay = pay;
+        this.webLink = webLink;
+        this.roadAddress = roadAddress;
+    }
 }

--- a/src/main/java/com/newworld/saegil/recruitment/domain/RecruitmentInfoSource.java
+++ b/src/main/java/com/newworld/saegil/recruitment/domain/RecruitmentInfoSource.java
@@ -1,0 +1,15 @@
+package com.newworld.saegil.recruitment.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum RecruitmentInfoSource {
+
+    SEOUL_DATA_SEOUL_JOB_PORTAL("서울열린데이터광장 서울시 일자리포털 채용 정보");
+
+    private final String name;
+
+    RecruitmentInfoSource(final String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/newworld/saegil/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/newworld/saegil/recruitment/repository/RecruitmentRepository.java
@@ -1,0 +1,7 @@
+package com.newworld.saegil.recruitment.repository;
+
+import com.newworld.saegil.recruitment.domain.Recruitment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+}

--- a/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentCrawler.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentCrawler.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.recruitment.service;
+
+import com.newworld.saegil.recruitment.domain.Recruitment;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RecruitmentCrawler {
+
+    List<Recruitment> crawl(final LocalDate requestDate);
+}

--- a/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentCrawler.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentCrawler.java
@@ -1,11 +1,14 @@
 package com.newworld.saegil.recruitment.service;
 
 import com.newworld.saegil.recruitment.domain.Recruitment;
+import com.newworld.saegil.recruitment.domain.RecruitmentInfoSource;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface RecruitmentCrawler {
+
+    RecruitmentInfoSource getSupportingRecruitmentInfoSource();
 
     List<Recruitment> crawl(final LocalDate requestDate);
 }

--- a/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentCrawlingService.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentCrawlingService.java
@@ -1,0 +1,79 @@
+package com.newworld.saegil.recruitment.service;
+
+import com.newworld.saegil.location.LocationInfo;
+import com.newworld.saegil.location.LocationInfoResolveFailedException;
+import com.newworld.saegil.location.LocationInfoResolver;
+import com.newworld.saegil.recruitment.domain.Recruitment;
+import com.newworld.saegil.recruitment.domain.RecruitmentInfoSource;
+import com.newworld.saegil.recruitment.repository.RecruitmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecruitmentCrawlingService {
+
+    private final Set<RecruitmentCrawler> crawlers;
+    private final LocationInfoResolver locationInfoResolver;
+    private final RecruitmentRepository recruitmentRepository;
+
+    public void fetchRecruitments(final LocalDate date) {
+        for (final RecruitmentCrawler crawler : crawlers) {
+            fetch(crawler, date);
+        }
+    }
+
+    private void fetch(final RecruitmentCrawler crawler, final LocalDate date) {
+        final RecruitmentInfoSource infoSource = crawler.getSupportingRecruitmentInfoSource();
+        log.info("전체 {} 크롤링 시작", infoSource.getName());
+        final long crawlStartTime = System.currentTimeMillis();
+        final List<Recruitment> totalCrawledRecruitments = crawler.crawl(date);
+        final long crawlEndTime = System.currentTimeMillis();
+        log.info("전체 {} 크롤링 완료.", infoSource.getName());
+        log.info("전체 {} 크롤링된 개수: {}", infoSource.getName(), totalCrawledRecruitments.size());
+        log.info("새로운 {} 개수: {}", infoSource.getName(), totalCrawledRecruitments.size());
+
+        log.info("{}개의 새로운 채용정보 좌표 찾기 시작", totalCrawledRecruitments.size());
+        final long locationInfoResolveStartTime = System.currentTimeMillis();
+        for (final Recruitment recruitment : totalCrawledRecruitments) {
+            try {
+                final LocationInfo locationInfo = locationInfoResolver.resolve(
+                        recruitment.getRoadAddress(),
+                        ""
+                );
+
+                recruitment.updateLocationInfo(locationInfo);
+            } catch (final LocationInfoResolveFailedException e) {
+                recruitment.markError(e);
+                log.error("채용정보({})의 근무지 위치 좌표를 찾을 수 없습니다: {}", recruitment.getName(), e.getMessage());
+            } catch (final Exception e) {
+                recruitment.markError(e);
+                log.error("채용정보({})의 근무지 위치 좌표를 찾는 중 알 수 없는 오류가 발생했습니다: {}", recruitment.getName(), e.getMessage());
+            }
+        }
+        final long locationInfoResolveEndTime = System.currentTimeMillis();
+        log.info("{}개의 새로운 채용정보 근무지 좌표 찾기 완료", totalCrawledRecruitments.size());
+
+        log.info("{}개의 새로운 채용정보 저장 시작", totalCrawledRecruitments.size());
+        final long saveStartTime = System.currentTimeMillis();
+        recruitmentRepository.saveAll(totalCrawledRecruitments);
+        final long saveEndTime = System.currentTimeMillis();
+        log.info("{}개의 새로운 채용정보 저장 완료", totalCrawledRecruitments.size());
+
+        log.info("{}개의 전체 {} 크롤링 소요 시간: {} ms",
+                totalCrawledRecruitments.size(), infoSource.getName(), crawlEndTime - crawlStartTime
+        );
+        log.info("{}개의 새로운 {} 좌표 찾기 소요 시간: {} ms",
+                totalCrawledRecruitments.size(), infoSource.getName(), locationInfoResolveEndTime - locationInfoResolveStartTime
+        );
+        log.info("{}개의 새로운 {} 저장 소요 시간: {} ms",
+                totalCrawledRecruitments.size(), infoSource.getName(), saveEndTime - saveStartTime
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/recruitment/service/crawler/SeoulJobPortalRecruitmentCrawler.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/crawler/SeoulJobPortalRecruitmentCrawler.java
@@ -33,6 +33,11 @@ public class SeoulJobPortalRecruitmentCrawler implements RecruitmentCrawler {
     private final RestTemplate restTemplate;
 
     @Override
+    public RecruitmentInfoSource getSupportingRecruitmentInfoSource() {
+        return RecruitmentInfoSource.SEOUL_DATA_SEOUL_JOB_PORTAL;
+    }
+
+    @Override
     public List<Recruitment> crawl(final LocalDate requestDate) {
         int startIndex = 1;
         int endIndex = 500;

--- a/src/main/java/com/newworld/saegil/recruitment/service/crawler/SeoulJobPortalRecruitmentCrawler.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/crawler/SeoulJobPortalRecruitmentCrawler.java
@@ -1,0 +1,147 @@
+package com.newworld.saegil.recruitment.service.crawler;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.newworld.saegil.recruitment.domain.Recruitment;
+import com.newworld.saegil.recruitment.domain.RecruitmentInfoSource;
+import com.newworld.saegil.recruitment.service.RecruitmentCrawler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeoulJobPortalRecruitmentCrawler implements RecruitmentCrawler {
+
+    @Value("${openapi.seoul-data.service-key}")
+    private String serviceKey;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public List<Recruitment> crawl(final LocalDate requestDate) {
+        int startIndex = 1;
+        int endIndex = 500;
+        int requestCount = 500;
+        final List<Recruitment> totalRecruitments = new ArrayList<>();
+        while (true) {
+            final String requestUri = createRequestUri(requestDate, startIndex, endIndex);
+            final SeoulJobPortalRecruitmentResponse response =
+                    restTemplate.getForObject(requestUri, SeoulJobPortalRecruitmentResponse.class);
+
+            if (response == null || response.isItemEmpty()) {
+                break;
+            }
+            final List<Recruitment> recruitments = response.getItems()
+                                                           .stream()
+                                                           .map(RecruitmentItem::toRecruitment)
+                                                           .toList();
+            totalRecruitments.addAll(recruitments);
+
+            startIndex += requestCount;
+            endIndex += requestCount;
+        }
+
+        return totalRecruitments;
+    }
+
+    @NotNull
+    private String createRequestUri(final LocalDate requestDate, final int startIndex, final int endIndex) {
+        final String blank = URLEncoder.encode(" ", StandardCharsets.UTF_8);
+
+        return UriComponentsBuilder.fromUriString("http://openapi.seoul.go.kr:8088")
+                                   .pathSegment(
+                                           serviceKey, "json", "GetJobInfo",
+                                           String.valueOf(startIndex),
+                                           String.valueOf(endIndex),
+                                           blank, blank, blank, blank,
+                                           requestDate.toString()
+                                   )
+                                   .build()
+                                   .toUriString();
+    }
+
+    record SeoulJobPortalRecruitmentResponse(
+            @JsonProperty("GetJobInfo")
+            Response getJobInfo
+    ) {
+
+        public boolean isItemEmpty() {
+            return getJobInfo == null || getJobInfo.rows == null || getJobInfo.rows.isEmpty();
+        }
+
+        public List<RecruitmentItem> getItems() {
+            return getJobInfo.rows;
+        }
+    }
+
+    record Response(
+            @JsonProperty("list_total_count")
+            int listTotalCount,
+
+            @JsonProperty("row")
+            List<RecruitmentItem> rows
+    ) {
+    }
+
+    record RecruitmentItem(
+            @JsonProperty("JO_REGIST_NO") String jobRegistNumber, // 구인등록번호
+            @JsonProperty("JO_SJ") String title, // 구인 제목
+            @JsonProperty("CMPNY_NM") String companyName, // 기업명칭
+            @JsonProperty("BASS_ADRES_CN") String workplaceAddress, // 근무지주소
+            @JsonProperty("HOLIDAY_NM") String weeklyWorkdays, // ex. 주 5일 근무
+            @JsonProperty("WORK_TIME_NM") String workTime, // 근무시간 ex "(근무시간) (오전) 9시 00분 ~ (오후) 6시 00분"
+            @JsonProperty("HOPE_WAGE") String wage, // 급여조건
+            @JsonProperty("JO_REG_DT") String jobRegisterDate, // 등록일
+            @JsonProperty("RCEPT_CLOS_NM") String receptionCloseDate // 마감일
+    ) {
+
+        public Recruitment toRecruitment() {
+            return new Recruitment(
+                    jobRegistNumber,
+                    RecruitmentInfoSource.SEOUL_DATA_SEOUL_JOB_PORTAL,
+                    title,
+                    LocalDate.parse(jobRegisterDate).atStartOfDay(),
+                    parseReceptionCloseDate(receptionCloseDate),
+                    weeklyWorkdays,
+                    workTime,
+                    wage,
+                    "",
+                    workplaceAddress
+            );
+        }
+
+        private LocalDateTime parseReceptionCloseDate(String receptionCloseDate) {
+            // "마감일 (2025-07-15)" 형식의 문자열에서 날짜 정보 파싱
+            Pattern pattern = Pattern.compile("\\((\\d{4}-\\d{2}-\\d{2}(?:\\s+\\d{2}:\\d{2})?)\\)");
+            Matcher matcher = pattern.matcher(receptionCloseDate);
+            if (!matcher.find()) {
+                return null;
+            }
+            String dateTimeStr = matcher.group(1);
+
+            if (dateTimeStr.contains(" ")) { // 날짜와 시간이 모두 있는 경우
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+                return LocalDateTime.parse(dateTimeStr, formatter);
+            }
+
+            // 날짜만 있는 경우
+            LocalDate date = LocalDate.parse(dateTimeStr);
+            return date.atStartOfDay();
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -56,6 +56,8 @@ openapi:
     private-decoding-key: ${PUBLIC_DATA_PRIVATE_DECODING_KEY:public-data-private-decoding-key}
     national-social-welfare-facility:
       api-uri: ${NATIONAL_SOCIAL_WELFARE_FACILITY_API_URI:national-social-welfare-facility-api-uri}
+  seoul-data:
+    service-key: ${SEOUL_DATA_SERVICE_KEY:seoul-data-service-key}
 
 geocoding:
   naver:


### PR DESCRIPTION
# 설명
- 기본적으로 이전에 사회복지시설데이터 저장하던 로직과 비슷합니다.
- 매일 1000건이 넘는 데이터 있는데, naver geocoding도 일정 요청 수 이상이면 과금이 되어서.. 안드측에서 이 기능 개발 완료하면 그때 스케줄링 돌리도록 하겠습니다. 그 전에 과금을 막을 방법을 찾아봐야겠어요

- closed #53 