### PR TITLE
feat: #65 주변 채용 정보 조회 api 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
@@ -34,6 +34,7 @@ public class WebConfiguration implements WebMvcConfigurer {
                 .excludePathPatterns("/swagger-ui/**")
                 .excludePathPatterns("/index.html")
                 .excludePathPatterns("/test-llm-proxy.html")
+                .excludePathPatterns("/api/v1/recruitments/**")
                 .excludePathPatterns("/api/v2/facilities/**")
                 .excludePathPatterns("/api/v1/organizations/**")
                 .excludePathPatterns("/api/v1/notices/**")

--- a/src/main/java/com/newworld/saegil/facility/repository/FacilityRepository.java
+++ b/src/main/java/com/newworld/saegil/facility/repository/FacilityRepository.java
@@ -22,5 +22,5 @@ public interface FacilityRepository extends JpaRepository<Facility, Long> {
               AND f.latitude BETWEEN :#{#geoBoundingBox.minLatitude} AND :#{#geoBoundingBox.maxLatitude}
               AND f.longitude BETWEEN :#{#geoBoundingBox.minLongitude} AND :#{#geoBoundingBox.maxLongitude}
             """)
-    List<Facility> findAllInBoundingBox(GeoBoundingBox geoBoundingBox);
+    List<Facility> findAllInBoundingBox(final GeoBoundingBox geoBoundingBox);
 }

--- a/src/main/java/com/newworld/saegil/recruitment/controller/ReadRecruitmentResponse.java
+++ b/src/main/java/com/newworld/saegil/recruitment/controller/ReadRecruitmentResponse.java
@@ -1,0 +1,57 @@
+package com.newworld.saegil.recruitment.controller;
+
+import com.newworld.saegil.recruitment.service.NearbyRecruitmentDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReadRecruitmentResponse(
+
+        @Schema(description = "채용 정보 식별자", example = "1")
+        Long id,
+
+        @Schema(description = "채용 정보 제목", example = "연동지역아동센터 생활복지사 구인")
+        String name,
+
+        @Schema(description = "근무지명", example = "연동지역아동센터")
+        String workPlaceName,
+
+        @Schema(description = "근무 시간", example = "(오전) 9시 00분 ~ (오후) 6시 00분 (주 5일 근무)")
+        String workTime,
+
+        @Schema(description = "임금", example = "월 200만원")
+        String pay,
+
+        @Schema(description= "지원 기간", example = "2025-04-29 ~ 2025-05-14")
+        String recruitmentPeriod,
+
+        @Schema(description = "채용 정보 웹 링크", example = "http://ceu.ssis.go.kr/")
+        String webLink,
+
+        @Schema(description = "근무지 주소", example = "서울특별시 양천구 신월로11길 16 (신월동, 한빛종합사회복지관)")
+        String address,
+
+        @Schema(description = "위도", example = "37.5190344")
+        double latitude,
+
+        @Schema(description = "경도", example = "126.8402373")
+        double longitude,
+
+        @Schema(description = "사용자 위치로부터의 거리 (미터)", example = "312.5")
+        double distanceMeters
+) {
+
+    public static ReadRecruitmentResponse from(final NearbyRecruitmentDto dto) {
+        return new ReadRecruitmentResponse(
+                dto.id(),
+                dto.name(),
+                dto.companyName(),
+                dto.workTime() + " (" + dto.weeklyWorkdays() + ")",
+                dto.pay(),
+                String.format("%s ~ %s", dto.recruitmentStartDate(), dto.recruitmentEndDate()),
+                dto.webLink(),
+                dto.roadAddress(),
+                dto.latitude(),
+                dto.longitude(),
+                dto.distanceMeters()
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/newworld/saegil/recruitment/controller/RecruitmentController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -27,25 +28,30 @@ public class RecruitmentController {
 
     @GetMapping("/nearby")
     @Operation(
-        summary = "근처 채용 정보 조회",
-        description = "사용자의 현재 위치와 반경을 기준으로 주변 채용 정보를 조회합니다. 지원 마감일이 지난 정보는 제외됩니다."
+            summary = "근처 채용 정보 조회",
+            description = "사용자의 현재 위치와 반경을 기준으로 주변 채용 정보를 조회합니다. 지원 마감일이 지난 정보는 제외됩니다."
     )
     @ApiResponse(responseCode = ApiResponseCode.OK, description = "근처 채용 정보 조회 성공")
     public ResponseEntity<List<ReadRecruitmentResponse>> readNearbyRecruitments(
-        @Parameter(description = "현재 위도", example = "37.5326")
-        @RequestParam double latitude,
+            @Parameter(description = "현재 위도", example = "37.5326")
+            @RequestParam double latitude,
 
-        @Parameter(description = "현재 경도", example = "126.8469")
-        @RequestParam double longitude,
+            @Parameter(description = "현재 경도", example = "126.8469")
+            @RequestParam double longitude,
 
-        @Parameter(description = "검색 반경 (미터 단위, 예: 500 / 1000 / 5000)", example = "1000")
-        @RequestParam final int radius
+            @Parameter(description = "검색 반경 (미터 단위, 예: 500 / 1000 / 5000)", example = "1000")
+            @RequestParam final int radius
     ) {
+        final LocalDateTime requestDateTime = LocalDateTime.now();
         final GeoPoint userGeoPoint = new GeoPoint(latitude, longitude);
-        final List<NearbyRecruitmentDto> result = recruitmentService.readNearbyRecruitments(userGeoPoint, radius);
+        final List<NearbyRecruitmentDto> result = recruitmentService.readNearbyRecruitments(
+                userGeoPoint,
+                radius,
+                requestDateTime
+        );
         final List<ReadRecruitmentResponse> response = result.stream()
-                                                            .map(ReadRecruitmentResponse::from)
-                                                            .toList();
+                                                             .map(ReadRecruitmentResponse::from)
+                                                             .toList();
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/newworld/saegil/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/newworld/saegil/recruitment/controller/RecruitmentController.java
@@ -1,0 +1,52 @@
+package com.newworld.saegil.recruitment.controller;
+
+import com.newworld.saegil.global.swagger.ApiResponseCode;
+import com.newworld.saegil.location.GeoPoint;
+import com.newworld.saegil.recruitment.service.NearbyRecruitmentDto;
+import com.newworld.saegil.recruitment.service.RecruitmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/recruitments")
+@RequiredArgsConstructor
+@Tag(name = "Recruiment", description = "채용 정보 API")
+public class RecruitmentController {
+
+    private final RecruitmentService recruitmentService;
+
+    @GetMapping("/nearby")
+    @Operation(
+        summary = "근처 채용 정보 조회",
+        description = "사용자의 현재 위치와 반경을 기준으로 주변 채용 정보를 조회합니다. 지원 마감일이 지난 정보는 제외됩니다."
+    )
+    @ApiResponse(responseCode = ApiResponseCode.OK, description = "근처 채용 정보 조회 성공")
+    public ResponseEntity<List<ReadRecruitmentResponse>> readNearbyRecruitments(
+        @Parameter(description = "현재 위도", example = "37.5326")
+        @RequestParam double latitude,
+
+        @Parameter(description = "현재 경도", example = "126.8469")
+        @RequestParam double longitude,
+
+        @Parameter(description = "검색 반경 (미터 단위, 예: 500 / 1000 / 5000)", example = "1000")
+        @RequestParam final int radius
+    ) {
+        final GeoPoint userGeoPoint = new GeoPoint(latitude, longitude);
+        final List<NearbyRecruitmentDto> result = recruitmentService.readNearbyRecruitments(userGeoPoint, radius);
+        final List<ReadRecruitmentResponse> response = result.stream()
+                                                            .map(ReadRecruitmentResponse::from)
+                                                            .toList();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
@@ -4,6 +4,8 @@ import com.newworld.saegil.location.GeoPoint;
 import com.newworld.saegil.location.LocationInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,11 +32,15 @@ public class Recruitment {
 
     private String recruitmentCode;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private RecruitmentInfoSource infoSource;
 
     @Column(nullable = false)
     private String name;
+
+    @Column(nullable = false)
+    private String companyName;
 
     private LocalDateTime recruitmentStartDate;
 
@@ -62,6 +68,7 @@ public class Recruitment {
             final String recruitmentCode,
             final RecruitmentInfoSource infoSource,
             final String name,
+            final String companyName,
             final LocalDateTime recruitmentStartDate,
             final LocalDateTime recruitmentEndDate,
             final String weeklyWorkdays,
@@ -73,6 +80,7 @@ public class Recruitment {
         this.recruitmentCode = recruitmentCode;
         this.infoSource = infoSource;
         this.name = name.trim();
+        this.companyName = companyName.trim();
         this.recruitmentStartDate = recruitmentStartDate;
         this.recruitmentEndDate = recruitmentEndDate;
         this.weeklyWorkdays = weeklyWorkdays.trim();

--- a/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/newworld/saegil/recruitment/domain/Recruitment.java
@@ -1,5 +1,6 @@
 package com.newworld.saegil.recruitment.domain;
 
+import com.newworld.saegil.location.GeoPoint;
 import com.newworld.saegil.location.LocationInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -101,5 +102,9 @@ public class Recruitment {
         } else {
             this.errorMessage = exceptionMeesage;
         }
+    }
+
+    public GeoPoint getGeoPoint() {
+        return new GeoPoint(latitude, longitude);
     }
 }

--- a/src/main/java/com/newworld/saegil/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/newworld/saegil/recruitment/repository/RecruitmentRepository.java
@@ -1,7 +1,20 @@
 package com.newworld.saegil.recruitment.repository;
 
+import com.newworld.saegil.location.GeoBoundingBox;
 import com.newworld.saegil.recruitment.domain.Recruitment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+
+    @Query("""
+            SELECT r
+            FROM Recruitment r
+            WHERE r.latitude IS NOT NULL AND r.longitude IS NOT NULL
+              AND r.latitude BETWEEN :#{#geoBoundingBox.minLatitude} AND :#{#geoBoundingBox.maxLatitude}
+              AND r.longitude BETWEEN :#{#geoBoundingBox.minLongitude} AND :#{#geoBoundingBox.maxLongitude}
+            """)
+    List<Recruitment> findAllInBoundingBox(final GeoBoundingBox geoBoundingBox);
 }

--- a/src/main/java/com/newworld/saegil/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/newworld/saegil/recruitment/repository/RecruitmentRepository.java
@@ -5,6 +5,7 @@ import com.newworld.saegil.recruitment.domain.Recruitment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
@@ -12,9 +13,10 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
     @Query("""
             SELECT r
             FROM Recruitment r
-            WHERE r.latitude IS NOT NULL AND r.longitude IS NOT NULL
+            WHERE NOT (r.recruitmentEndDate < :targetDateTime)
+              AND r.latitude IS NOT NULL AND r.longitude IS NOT NULL
               AND r.latitude BETWEEN :#{#geoBoundingBox.minLatitude} AND :#{#geoBoundingBox.maxLatitude}
               AND r.longitude BETWEEN :#{#geoBoundingBox.minLongitude} AND :#{#geoBoundingBox.maxLongitude}
             """)
-    List<Recruitment> findAllInBoundingBox(final GeoBoundingBox geoBoundingBox);
+    List<Recruitment> findAllActiveInBoundingBox(final GeoBoundingBox geoBoundingBox, final LocalDateTime targetDateTime);
 }

--- a/src/main/java/com/newworld/saegil/recruitment/service/NearbyRecruitmentDto.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/NearbyRecruitmentDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 public record NearbyRecruitmentDto(
         Long id,
         String name,
+        String companyName,
         LocalDateTime recruitmentStartDate,
         LocalDateTime recruitmentEndDate,
         String weeklyWorkdays,
@@ -23,6 +24,7 @@ public record NearbyRecruitmentDto(
         return new NearbyRecruitmentDto(
                 recruitment.getId(),
                 recruitment.getName(),
+                recruitment.getCompanyName(),
                 recruitment.getRecruitmentStartDate(),
                 recruitment.getRecruitmentEndDate(),
                 recruitment.getWeeklyWorkdays(),

--- a/src/main/java/com/newworld/saegil/recruitment/service/NearbyRecruitmentDto.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/NearbyRecruitmentDto.java
@@ -1,0 +1,38 @@
+package com.newworld.saegil.recruitment.service;
+
+import com.newworld.saegil.recruitment.domain.Recruitment;
+
+import java.time.LocalDateTime;
+
+public record NearbyRecruitmentDto(
+        Long id,
+        String name,
+        LocalDateTime recruitmentStartDate,
+        LocalDateTime recruitmentEndDate,
+        String weeklyWorkdays,
+        String workTime,
+        String pay,
+        String webLink,
+        String roadAddress,
+        double latitude,
+        double longitude,
+        double distanceMeters
+) {
+
+    public static NearbyRecruitmentDto from(final Recruitment recruitment, final double distanceMeters) {
+        return new NearbyRecruitmentDto(
+                recruitment.getId(),
+                recruitment.getName(),
+                recruitment.getRecruitmentStartDate(),
+                recruitment.getRecruitmentEndDate(),
+                recruitment.getWeeklyWorkdays(),
+                recruitment.getWorkTime(),
+                recruitment.getPay(),
+                recruitment.getWebLink(),
+                recruitment.getRoadAddress(),
+                recruitment.getLatitude(),
+                recruitment.getLongitude(),
+                distanceMeters
+        );
+    }
+}

--- a/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -20,14 +21,16 @@ public class RecruitmentService {
 
     public List<NearbyRecruitmentDto> readNearbyRecruitments(
             final GeoPoint baseGeoPoint,
-            final int radius
+            final int radius,
+            final LocalDateTime targetDateTime
     ) {
         final GeoBoundingBox geoBoundingBox = GeoUtils.calculateBoundingBox(
                 baseGeoPoint.latitude(),
                 baseGeoPoint.longitude(),
                 radius
         );
-        final List<Recruitment> recruitmentsInBoundingBox = recruitmentRepository.findAllInBoundingBox(geoBoundingBox);
+        final List<Recruitment> recruitmentsInBoundingBox =
+                recruitmentRepository.findAllActiveInBoundingBox(geoBoundingBox, targetDateTime);
 
         return recruitmentsInBoundingBox.stream()
                                         .map(recruitment -> NearbyRecruitmentDto.from(

--- a/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/RecruitmentService.java
@@ -1,0 +1,39 @@
+package com.newworld.saegil.recruitment.service;
+
+import com.newworld.saegil.location.GeoBoundingBox;
+import com.newworld.saegil.location.GeoPoint;
+import com.newworld.saegil.location.GeoUtils;
+import com.newworld.saegil.recruitment.domain.Recruitment;
+import com.newworld.saegil.recruitment.repository.RecruitmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecruitmentService {
+
+    private final RecruitmentRepository recruitmentRepository;
+
+    public List<NearbyRecruitmentDto> readNearbyRecruitments(
+            final GeoPoint baseGeoPoint,
+            final int radius
+    ) {
+        final GeoBoundingBox geoBoundingBox = GeoUtils.calculateBoundingBox(
+                baseGeoPoint.latitude(),
+                baseGeoPoint.longitude(),
+                radius
+        );
+        final List<Recruitment> recruitmentsInBoundingBox = recruitmentRepository.findAllInBoundingBox(geoBoundingBox);
+
+        return recruitmentsInBoundingBox.stream()
+                                        .map(recruitment -> NearbyRecruitmentDto.from(
+                                                recruitment,
+                                                GeoUtils.calculateDistanceMeters(baseGeoPoint, recruitment.getGeoPoint())
+                                        )).filter(recruitmentDto -> recruitmentDto.distanceMeters() <= radius)
+                                        .toList();
+    }
+}

--- a/src/main/java/com/newworld/saegil/recruitment/service/crawler/SeoulJobPortalRecruitmentCrawler.java
+++ b/src/main/java/com/newworld/saegil/recruitment/service/crawler/SeoulJobPortalRecruitmentCrawler.java
@@ -120,6 +120,7 @@ public class SeoulJobPortalRecruitmentCrawler implements RecruitmentCrawler {
                     jobRegistNumber,
                     RecruitmentInfoSource.SEOUL_DATA_SEOUL_JOB_PORTAL,
                     title,
+                    companyName,
                     LocalDate.parse(jobRegisterDate).atStartOfDay(),
                     parseReceptionCloseDate(receptionCloseDate),
                     weeklyWorkdays,


### PR DESCRIPTION
# 설명

- 주변 시설 정보 조회 기능과 비슷합니다.
- 요청 날짜가 지원 마감날짜 이전인 데이터만 조회합니다.
- closed #65 