### PR TITLE
파일 업로드 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
+++ b/src/main/java/com/newworld/saegil/configuration/WebConfiguration.java
@@ -34,6 +34,7 @@ public class WebConfiguration implements WebMvcConfigurer {
                 .excludePathPatterns("/swagger-ui/**")
                 .excludePathPatterns("/index.html")
                 .excludePathPatterns("/test-llm-proxy.html")
+                .excludePathPatterns("/files/**")
                 .excludePathPatterns("/api/v1/recruitments/**")
                 .excludePathPatterns("/api/v1/facilities/**")
                 .excludePathPatterns("/api/v1/organizations/**")

--- a/src/main/java/com/newworld/saegil/file/controller/FileController.java
+++ b/src/main/java/com/newworld/saegil/file/controller/FileController.java
@@ -2,6 +2,7 @@ package com.newworld.saegil.file.controller;
 
 import com.newworld.saegil.file.service.FileDto;
 import com.newworld.saegil.file.service.FileService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,10 +13,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URI;
 
 @RestController
 @RequestMapping("/files")
@@ -37,5 +42,16 @@ public class FileController {
         headers.setContentType(fileDto.contentType());
 
         return new ResponseEntity<>(fileDto.file(), headers, HttpStatus.OK);
+    }
+
+    @Hidden // 업로드 테스트 및 관리자 모드에 사용 예정
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadFile(
+            @RequestParam("file") final MultipartFile file
+    ) {
+        final String fileUrl = fileService.upload(file);
+
+        return ResponseEntity.created(URI.create(fileUrl))
+                .body("파일이 성공적으로 업로드되었습니다. URL: " + fileUrl);
     }
 }

--- a/src/main/java/com/newworld/saegil/file/controller/FileController.java
+++ b/src/main/java/com/newworld/saegil/file/controller/FileController.java
@@ -1,0 +1,41 @@
+package com.newworld.saegil.file.controller;
+
+import com.newworld.saegil.file.service.FileDto;
+import com.newworld.saegil.file.service.FileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/files")
+@RequiredArgsConstructor
+@Tag(name = "File", description = "파일 API")
+public class FileController {
+
+    private final FileService fileService;
+
+    @GetMapping("/{storeName}")
+    @Operation(summary = "서버에 저장된 파일 요청")
+    public ResponseEntity<Resource> read(
+            @Parameter(description = "파일 이름", example = "asdfasdfasdf.png")
+            @PathVariable final String storeName
+    ) throws IOException {
+        final FileDto fileDto = fileService.read(storeName);
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(fileDto.contentType());
+
+        return new ResponseEntity<>(fileDto.file(), headers, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/newworld/saegil/file/service/FileDto.java
+++ b/src/main/java/com/newworld/saegil/file/service/FileDto.java
@@ -1,0 +1,10 @@
+package com.newworld.saegil.file.service;
+
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+
+public record FileDto(
+        Resource file,
+        MediaType contentType
+) {
+}

--- a/src/main/java/com/newworld/saegil/file/service/FileProcessor.java
+++ b/src/main/java/com/newworld/saegil/file/service/FileProcessor.java
@@ -1,0 +1,15 @@
+package com.newworld.saegil.file.service;
+
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface FileProcessor {
+
+    String upload(final MultipartFile multipartFile);
+
+    List<String> uploadAll(final List<MultipartFile> multipartFiles);
+
+    String getFileStorePath(final String storeName);
+}

--- a/src/main/java/com/newworld/saegil/file/service/FileService.java
+++ b/src/main/java/com/newworld/saegil/file/service/FileService.java
@@ -1,0 +1,48 @@
+package com.newworld.saegil.file.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FileService {
+
+    private static final String FILE_PROTOCOL_PREFIX = "file:";
+
+    private final FileProcessor fileProcessor;
+
+    public FileDto read(final String storeName) throws IOException {
+        final String storePath = fileProcessor.getFileStorePath(storeName);
+        final Resource file = new UrlResource(FILE_PROTOCOL_PREFIX + storePath);
+        validateFile(file, storeName);
+        final MediaType contentType = extractContentType(file);
+
+        return new FileDto(file, contentType);
+    }
+
+    private void validateFile(final Resource file, final String storeName) {
+        if (!file.exists() || !file.isReadable()) {
+            throw new ReadFailureException("파일[" + storeName + "]이 존재하지 않거나 읽을 수 없습니다.");
+        }
+    }
+
+    private MediaType extractContentType(final Resource resource) throws IOException {
+        final Path filePath = Paths.get(resource.getURI());
+        String contentType = Files.probeContentType(filePath);
+        if (contentType == null) {
+            contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+        }
+
+        return MediaType.parseMediaType(contentType);
+    }
+}

--- a/src/main/java/com/newworld/saegil/file/service/FileService.java
+++ b/src/main/java/com/newworld/saegil/file/service/FileService.java
@@ -6,6 +6,7 @@ import org.springframework.core.io.UrlResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -20,6 +21,10 @@ public class FileService {
     private static final String FILE_PROTOCOL_PREFIX = "file:";
 
     private final FileProcessor fileProcessor;
+
+    public String upload(final MultipartFile multipartFile) {
+        return fileProcessor.upload(multipartFile);
+    }
 
     public FileDto read(final String storeName) throws IOException {
         final String storePath = fileProcessor.getFileStorePath(storeName);

--- a/src/main/java/com/newworld/saegil/file/service/InvalidFileException.java
+++ b/src/main/java/com/newworld/saegil/file/service/InvalidFileException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.file.service;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidFileException extends CustomException {
+
+    public InvalidFileException(final String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/newworld/saegil/file/service/LocalFileProcessor.java
+++ b/src/main/java/com/newworld/saegil/file/service/LocalFileProcessor.java
@@ -39,7 +39,9 @@ public class LocalFileProcessor implements FileProcessor {
 
     private void upload(final MultipartFile multipartFile, final String uploadPath) {
         try {
-            multipartFile.transferTo(new File(uploadPath));
+            final File file = new File(uploadPath);
+            file.getParentFile().mkdirs();
+            multipartFile.transferTo(file);
         } catch (IOException ex) {
             throw new StoreFailureException("파일 저장에 실패했습니다.");
         }

--- a/src/main/java/com/newworld/saegil/file/service/LocalFileProcessor.java
+++ b/src/main/java/com/newworld/saegil/file/service/LocalFileProcessor.java
@@ -1,0 +1,75 @@
+package com.newworld.saegil.file.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class LocalFileProcessor implements FileProcessor {
+
+    private static final List<String> EXTENSION = List.of("jpg", "jpeg", "png");
+    private static final String EXTENSION_SEPARATOR = ".";
+
+    @Value("${file.upload.path}")
+    private String uploadPath;
+
+    @Value("${file.web.path}")
+    private String webApiPath;
+
+    @Override
+    public String upload(final MultipartFile multipartFile) {
+        if (multipartFile.isEmpty()) {
+            throw new InvalidFileException("파일이 비어있습니다.");
+        }
+        final String originalFileName = multipartFile.getOriginalFilename();
+        if (originalFileName == null) {
+            throw new InvalidFileException("파일 이름이 비어있습니다.");
+        }
+        final String storeFileName = createStoreFileName(originalFileName);
+        final String uploadFullPath = this.uploadPath + storeFileName;
+        upload(multipartFile, uploadFullPath);
+
+        return webApiPath + storeFileName;
+    }
+
+    private void upload(final MultipartFile multipartFile, final String uploadPath) {
+        try {
+            multipartFile.transferTo(new File(uploadPath));
+        } catch (IOException ex) {
+            throw new StoreFailureException("파일 저장에 실패했습니다.");
+        }
+    }
+
+    @Override
+    public List<String> uploadAll(final List<MultipartFile> multipartFiles) {
+        return multipartFiles.stream()
+                .map(this::upload)
+                .toList();
+    }
+
+    private String createStoreFileName(final String originalFilename) {
+        final String extension = extractExtension(originalFilename);
+        final String uuid = UUID.randomUUID().toString();
+
+        return uuid + EXTENSION_SEPARATOR + extension;
+    }
+
+    private String extractExtension(final String originalFilename) {
+        final String extension = originalFilename.substring(originalFilename.lastIndexOf(EXTENSION_SEPARATOR) + 1);
+        if (!EXTENSION.contains(extension.toLowerCase())) {
+            throw new UnsupportedFileExtensionException("지원하지 않는 확장자입니다. : " + extension);
+        }
+
+        return extension;
+    }
+
+    @Override
+    public String getFileStorePath(final String storeName) {
+        return uploadPath + storeName;
+    }
+}

--- a/src/main/java/com/newworld/saegil/file/service/ReadFailureException.java
+++ b/src/main/java/com/newworld/saegil/file/service/ReadFailureException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.file.service;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class ReadFailureException extends CustomException {
+
+    public ReadFailureException(final String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/newworld/saegil/file/service/StoreFailureException.java
+++ b/src/main/java/com/newworld/saegil/file/service/StoreFailureException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.file.service;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class StoreFailureException extends CustomException {
+
+    public StoreFailureException(final String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/newworld/saegil/file/service/UnsupportedFileExtensionException.java
+++ b/src/main/java/com/newworld/saegil/file/service/UnsupportedFileExtensionException.java
@@ -1,0 +1,11 @@
+package com.newworld.saegil.file.service;
+
+import com.newworld.saegil.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class UnsupportedFileExtensionException extends CustomException {
+
+    public UnsupportedFileExtensionException(final String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -82,3 +82,8 @@ logging:
   file:
     name:
     path:
+file:
+  upload:
+    path: ${FILE_LOCAL_UPLOAD_PATH:/Users/kwon-yejin/Downloads/}
+  web:
+    path: ${FILE_GET_API_PATH:http://localhost:8080/files/}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -84,6 +84,6 @@ logging:
     path:
 file:
   upload:
-    path: ${FILE_LOCAL_UPLOAD_PATH:/Users/kwon-yejin/Downloads/}
+    path: ${FILE_LOCAL_UPLOAD_PATH}
   web:
     path: ${FILE_GET_API_PATH:http://localhost:8080/files/}


### PR DESCRIPTION
# 설명

나중에 퀴즈할 때 이미지가 필요할 수도 있을 것 같고 있으면 쓸 일이 종종 있을 것 같아 미리 만들어 두었어요.
일단 jpg, jpeg, png만 가능하게 설정해두었는데, 나중에 필요하면 지원하는 확장자 추가하면 됩니다.

### 업로드
아래처럼 post 요청으로 업로드할 수 있습니다.
post 요청에 대한 응답으로 오는 url을 브라우저에 입력하면 파일 조회할 수 있어요.
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/8275db7d-bdee-4572-950d-ffa03a751371" />
